### PR TITLE
release: v1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/.vitepress/cache
 # Claude settings
 .claude/*
 !.claude/skills/
+.vscode-diagnostics.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-03-05
+
+### Added
+
+- Twine spec compliance test suites in `specs/` validated against the official [iftechfoundation/twine-specs](https://github.com/iftechfoundation/twine-specs):
+  - `twine1-htmloutput-spec.test.ts` — 34 tests covering Twine 1 HTML output (root structure, passage attributes, tiddler escaping, special passages, Twine.private filtering)
+  - `twine2-htmloutput-spec.test.ts` — 59 tests covering Twine 2 HTML output
+  - `twine2-archive-spec.test.ts` — 20 tests covering Twine 2 archive output
+  - `twine2-jsonoutput-spec.test.ts` — 39 tests covering Twine 2 JSON output
+  - `twine2-storyformats-spec.test.ts` — 21 tests covering story format discovery
+  - `twee3-spec.test.ts` — 125 tests covering Twee 3 syntax
+- Spec test suites included in vitest config (`specs/**/*.test.ts`)
+
+### Changed
+
+- JSON output now follows the [Twine 2 JSON Output Specification](https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-jsonoutput-doc.md): top-level `format`, `format-version`, `start`, `tag-colors`, `zoom`, `creator`, `creator-version`, `style`, `script` keys instead of nested `twine2` object
+- JSON output excludes `StoryTitle`, `StoryData`, `Twine.private`, `script`, and `stylesheet` passages from the passages array (scripts/stylesheets merged into top-level `style`/`script` fields)
+- Missing IFID diagnostic changed from `warning` to `error` with actionable message showing the required StoryData JSON
+- Twine 2 zoom attribute uses `String()` instead of conditional `toFixed(1)` for simpler, lossless formatting
+
+### Fixed
+
+- IFID is now set on the story object before the diagnostic is pushed (consistent ordering)
+- `.vscode-diagnostics.json` added to `.gitignore`
+
 ## [1.2.0] - 2026-03-05
 
 ### Added

--- a/specs/twee3-spec.test.ts
+++ b/specs/twee3-spec.test.ts
@@ -1,0 +1,1220 @@
+/**
+ * Twee 3 Specification Compliance Tests
+ *
+ * Tests twee-ts against every requirement in the Twee 3 Specification (v3.0.2):
+ * https://github.com/iftechfoundation/twine-specs/blob/master/twee-3-specification.md
+ *
+ * Each describe block corresponds to a section of the spec.
+ * Tests are labeled with MUST (required) or RECOMMENDED (encouraged).
+ */
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { parseTwee } from '../src/parser.js';
+import { compile } from '../src/compiler.js';
+import { tweeLexer } from '../src/lexer.js';
+import { ItemType } from '../src/types.js';
+import type { LexerItem } from '../src/types.js';
+
+const FIXTURES_DIR = join(__dirname, '..', 'test', 'fixtures');
+const FORMAT_DIR = join(FIXTURES_DIR, 'storyformats');
+
+/** Helper: collect all lexer items from input. */
+function lex(input: string): LexerItem[] {
+  return [...tweeLexer(input)];
+}
+
+/** Helper: compile inline twee source to HTML. */
+async function compileInline(content: string, options: Record<string, unknown> = {}) {
+  return compile({
+    sources: [{ filename: 'spec-test.tw', content }],
+    formatId: 'test-format-1',
+    formatPaths: [FORMAT_DIR],
+    useTweegoPath: false,
+    ...options,
+  });
+}
+
+/** Helper: build a minimal valid twee source with StoryData and StoryTitle. */
+function minimalStory(passages: string): string {
+  return [
+    ':: StoryData',
+    '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}',
+    '',
+    ':: StoryTitle',
+    'Spec Test',
+    '',
+    passages,
+  ].join('\n');
+}
+
+// =============================================================================
+// Section: Twee Notation — File Composition
+// "Twee files are composed of one or more passages."
+// =============================================================================
+
+describe('Twee Notation — File Composition', () => {
+  it('parses a file with a single passage', () => {
+    const { passages, diagnostics } = parseTwee(':: Start\nHello');
+    expect(diagnostics).toHaveLength(0);
+    expect(passages).toHaveLength(1);
+  });
+
+  it('parses a file with multiple passages', () => {
+    const { passages, diagnostics } = parseTwee(':: First\nContent 1\n\n:: Second\nContent 2\n\n:: Third\nContent 3');
+    expect(diagnostics).toHaveLength(0);
+    expect(passages).toHaveLength(3);
+  });
+});
+
+// =============================================================================
+// Section: Passage Header
+// "Each header must be a single line"
+// =============================================================================
+
+describe('Passage Header', () => {
+  // -------------------------------------------------------------------------
+  // Component 1: Required start token (::)
+  // "Required start token, a double colon (::), that must begin the line."
+  // -------------------------------------------------------------------------
+  describe('Start Token (::)', () => {
+    it('MUST: recognizes :: at the beginning of a line as a passage header', () => {
+      const items = lex(':: Start\nContent');
+      expect(items[0]!.type).toBe(ItemType.Header);
+      expect(items[0]!.val).toBe('::');
+    });
+
+    it('MUST: recognizes :: at the beginning of the file', () => {
+      const { passages } = parseTwee(':: Start\nContent');
+      expect(passages).toHaveLength(1);
+      expect(passages[0]!.name).toBe('Start');
+    });
+
+    it('MUST: recognizes :: at the beginning of a subsequent line', () => {
+      const { passages } = parseTwee('Some prolog text\n:: Start\nContent');
+      expect(passages).toHaveLength(1);
+      expect(passages[0]!.name).toBe('Start');
+    });
+
+    it('does not treat :: in the middle of a line as a header', () => {
+      const { passages } = parseTwee(':: Start\nSome :: text here');
+      expect(passages).toHaveLength(1);
+      expect(passages[0]!.text).toContain('Some :: text here');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Component 2: Required passage name
+  // -------------------------------------------------------------------------
+  describe('Passage Name', () => {
+    it('MUST: parses the passage name after ::', () => {
+      const { passages } = parseTwee(':: My Passage Name\nContent');
+      expect(passages[0]!.name).toBe('My Passage Name');
+    });
+
+    it('MUST: allows spaces before the passage name for readability', () => {
+      const { passages } = parseTwee('::   Spaced Name\nContent');
+      expect(passages[0]!.name).toBe('Spaced Name');
+    });
+
+    it('reports an error for a passage with no name', () => {
+      const { diagnostics } = parseTwee(':: \nContent');
+      expect(diagnostics.length).toBeGreaterThan(0);
+      expect(diagnostics[0]!.level).toBe('error');
+    });
+
+    it('RECOMMENDED: warns on duplicate passage names', async () => {
+      const result = await compileInline(minimalStory(':: Duplicate\nFirst\n\n:: Duplicate\nSecond'));
+      const dupWarnings = result.diagnostics.filter(
+        (d) => d.message.toLowerCase().includes('duplicate') || d.message.toLowerCase().includes('replacing'),
+      );
+      expect(dupWarnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Component 3: Optional tag block
+  // "Optional tag block that must directly follow the passage name"
+  // -------------------------------------------------------------------------
+  describe('Tag Block', () => {
+    it('MUST: parses tags enclosed in square brackets', () => {
+      const { passages } = parseTwee(':: Room [forest spooky]\nContent');
+      expect(passages[0]!.tags).toEqual(['forest', 'spooky']);
+    });
+
+    it('MUST: tags are space-separated', () => {
+      const { passages } = parseTwee(':: Room [a b c d]\nContent');
+      expect(passages[0]!.tags).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('MUST: tag block directly follows the passage name', () => {
+      const { passages } = parseTwee(':: Room [tag1]\nContent');
+      expect(passages[0]!.name).toBe('Room');
+      expect(passages[0]!.tags).toEqual(['tag1']);
+    });
+
+    it('handles empty tag block', () => {
+      const { passages } = parseTwee(':: Room []\nContent');
+      expect(passages[0]!.tags).toEqual([]);
+    });
+
+    it('MUST: tags must not contain spaces (each tag is a separate word)', () => {
+      const { passages } = parseTwee(':: Room [multi word tag]\nContent');
+      // Each space-separated word is a separate tag
+      expect(passages[0]!.tags).toEqual(['multi', 'word', 'tag']);
+    });
+
+    it('reports error for unterminated tag block', () => {
+      const { diagnostics } = parseTwee(':: Room [unclosed\nContent');
+      expect(diagnostics.length).toBeGreaterThan(0);
+      expect(diagnostics[0]!.level).toBe('error');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Component 4: Optional metadata block
+  // "Optional metadata block, an inline JSON chunk"
+  // -------------------------------------------------------------------------
+  describe('Metadata Block', () => {
+    it('MUST: parses metadata as inline JSON', () => {
+      const { passages } = parseTwee(':: Room {"position":"600,400","size":"100,200"}\nContent');
+      expect(passages[0]!.metadata).toEqual({ position: '600,400', size: '100,200' });
+    });
+
+    it('MUST: metadata block directly follows tag block when tags are present', () => {
+      const { passages } = parseTwee(':: Room [forest] {"position":"100,100"}\nContent');
+      expect(passages[0]!.tags).toEqual(['forest']);
+      expect(passages[0]!.metadata).toEqual({ position: '100,100' });
+    });
+
+    it('MUST: metadata block directly follows passage name when tags are omitted', () => {
+      const { passages } = parseTwee(':: Room {"position":"100,100"}\nContent');
+      expect(passages[0]!.name).toBe('Room');
+      expect(passages[0]!.metadata).toEqual({ position: '100,100' });
+    });
+
+    it('MUST: supports position property', () => {
+      const { passages } = parseTwee(':: Room {"position":"600,400"}\nContent');
+      expect(passages[0]!.metadata?.position).toBe('600,400');
+    });
+
+    it('MUST: supports size property', () => {
+      const { passages } = parseTwee(':: Room {"size":"100,200"}\nContent');
+      expect(passages[0]!.metadata?.size).toBe('100,200');
+    });
+
+    it('RECOMMENDED: emits warning on metadata decode error and continues', () => {
+      const { passages, diagnostics } = parseTwee(':: Room {invalid json}\nContent');
+      // Should warn, not error fatally
+      const warnings = diagnostics.filter((d) => d.level === 'warning');
+      expect(warnings.length).toBeGreaterThan(0);
+      // Should still have the passage
+      expect(passages).toHaveLength(1);
+      expect(passages[0]!.name).toBe('Room');
+    });
+
+    it('reports error for unterminated metadata block', () => {
+      const { diagnostics } = parseTwee(':: Room {unclosed\nContent');
+      expect(diagnostics.length).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Component order
+  // "Each component after the start token may be preceded by one or more spaces"
+  // -------------------------------------------------------------------------
+  describe('Component Ordering and Spacing', () => {
+    it('MUST: components may be preceded by spaces', () => {
+      // Space between :: and name
+      const { passages } = parseTwee('::  Room  [tag] {"position":"1,1"}\nContent');
+      expect(passages[0]!.name).toBe('Room');
+      expect(passages[0]!.tags).toEqual(['tag']);
+    });
+
+    it('MUST: all four components together in order', () => {
+      const { passages } = parseTwee(
+        ':: An overgrown path [forest spooky] {"position":"600,400","size":"100,200"}\nContent',
+      );
+      expect(passages[0]!.name).toBe('An overgrown path');
+      expect(passages[0]!.tags).toEqual(['forest', 'spooky']);
+      expect(passages[0]!.metadata).toEqual({ position: '600,400', size: '100,200' });
+    });
+
+    it('minimal: start token and name only', () => {
+      const { passages } = parseTwee(':: An overgrown path\nContent');
+      expect(passages[0]!.name).toBe('An overgrown path');
+      expect(passages[0]!.tags).toEqual([]);
+    });
+
+    it('name with tags only (no metadata)', () => {
+      const { passages } = parseTwee(':: An overgrown path [forest spooky]\nContent');
+      expect(passages[0]!.name).toBe('An overgrown path');
+      expect(passages[0]!.tags).toEqual(['forest', 'spooky']);
+    });
+
+    it('name with metadata only (no tags)', () => {
+      const { passages } = parseTwee(':: An overgrown path {"position":"600,400","size":"100,200"}\nContent');
+      expect(passages[0]!.name).toBe('An overgrown path');
+      expect(passages[0]!.metadata).toEqual({ position: '600,400', size: '100,200' });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Escapement
+  // "passage and tag names that include [ ] { } must escape them with \"
+  // -------------------------------------------------------------------------
+  describe('Escapement', () => {
+    it('MUST: unescapes \\[ in passage names', () => {
+      const { passages } = parseTwee(':: Name\\[1\\]\nContent');
+      expect(passages[0]!.name).toBe('Name[1]');
+    });
+
+    it('MUST: unescapes \\] in passage names', () => {
+      const { passages } = parseTwee(':: Name\\]test\nContent');
+      expect(passages[0]!.name).toBe('Name]test');
+    });
+
+    it('MUST: unescapes \\{ in passage names', () => {
+      const { passages } = parseTwee(':: Name\\{test\nContent');
+      expect(passages[0]!.name).toBe('Name{test');
+    });
+
+    it('MUST: unescapes \\} in passage names', () => {
+      const { passages } = parseTwee(':: Name\\}test\nContent');
+      expect(passages[0]!.name).toBe('Name}test');
+    });
+
+    it('MUST: non-escape backslashes must also be escaped (\\\\)', () => {
+      const { passages } = parseTwee(':: foo\\\\bar\nContent');
+      expect(passages[0]!.name).toBe('foo\\bar');
+    });
+
+    it('MUST: decoding — any escaped character yields the character minus backslash', () => {
+      // \q must yield q
+      const { passages } = parseTwee(':: foo\\qbar\nContent');
+      expect(passages[0]!.name).toBe('fooqbar');
+    });
+
+    it('MUST: unescapes metacharacters in tag names', () => {
+      const { passages } = parseTwee(':: Room [tag\\[1\\]]\nContent');
+      expect(passages[0]!.tags).toContain('tag[1]');
+    });
+  });
+});
+
+// =============================================================================
+// Section: Passage Content
+// "The content section begins on the next line after the passage header"
+// =============================================================================
+
+describe('Passage Content', () => {
+  it('MUST: content begins on the next line after the header', () => {
+    const { passages } = parseTwee(':: Start\nThis is content');
+    expect(passages[0]!.text).toBe('This is content');
+  });
+
+  it('MUST: content continues until the next passage header', () => {
+    const { passages } = parseTwee(':: First\nLine 1\nLine 2\n\n:: Second\nOther');
+    expect(passages[0]!.text).toContain('Line 1');
+    expect(passages[0]!.text).toContain('Line 2');
+    expect(passages[1]!.text).toBe('Other');
+  });
+
+  it('MUST: content continues until the end of file', () => {
+    const { passages } = parseTwee(':: Start\nContent to the end');
+    expect(passages[0]!.text).toBe('Content to the end');
+  });
+
+  it('MUST: trailing blank lines must be ignored/omitted', () => {
+    const { passages } = parseTwee(':: Start\nContent\n\n\n');
+    expect(passages[0]!.text).toBe('Content');
+    // No trailing newlines
+    expect(passages[0]!.text.endsWith('\n')).toBe(false);
+  });
+
+  it('MUST: trailing blank lines omitted between passages', () => {
+    const { passages } = parseTwee(':: First\nContent 1\n\n\n\n:: Second\nContent 2');
+    expect(passages[0]!.text).toBe('Content 1');
+    expect(passages[0]!.text.endsWith('\n')).toBe(false);
+  });
+
+  it('preserves internal blank lines in content', () => {
+    const { passages } = parseTwee(':: Start\nLine 1\n\nLine 3');
+    expect(passages[0]!.text).toContain('Line 1');
+    expect(passages[0]!.text).toContain('Line 3');
+  });
+
+  it('handles passage with empty content', () => {
+    const { passages } = parseTwee(':: Empty\n\n:: Next\nContent');
+    expect(passages[0]!.name).toBe('Empty');
+    expect(passages[0]!.text).toBe('');
+    expect(passages[1]!.name).toBe('Next');
+  });
+});
+
+// =============================================================================
+// Section: Special Passages — StoryTitle
+// "The project's name. Maps to <tw-storydata name>."
+// =============================================================================
+
+describe('Special Passages — StoryTitle', () => {
+  it('MUST: StoryTitle sets the story name', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.story.name).toBe('Spec Test');
+  });
+
+  it('MUST: StoryTitle maps to tw-storydata name attribute', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toContain('name="Spec Test"');
+  });
+
+  it('trims whitespace from StoryTitle content', () => {
+    const { passages } = parseTwee(':: StoryTitle\n  My Story  \n\n:: Start\nHello');
+    const titlePassage = passages.find((p) => p.name === 'StoryTitle');
+    expect(titlePassage!.text).toBe('My Story');
+  });
+});
+
+// =============================================================================
+// Section: Special Passages — StoryData
+// "A JSON chunk encapsulating various Twine 2 compatible details"
+// =============================================================================
+
+describe('Special Passages — StoryData', () => {
+  describe('ifid property', () => {
+    it('MUST: ifid is parsed from StoryData JSON', async () => {
+      const result = await compileInline(minimalStory(':: Start\nHello'));
+      expect(result.story.ifid).toBe('D674C58C-DEFA-4F70-B7A2-27742230C0FC');
+    });
+
+    it('MUST: ifid maps to tw-storydata ifid attribute', async () => {
+      const result = await compileInline(minimalStory(':: Start\nHello'));
+      expect(result.output).toContain('ifid="D674C58C-DEFA-4F70-B7A2-27742230C0FC"');
+    });
+
+    it('MUST: IFID uses only capital letters (uppercase UUIDs)', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"d674c58c-defa-4f70-b7a2-27742230c0fc"}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      // Must be uppercased
+      expect(result.story.ifid).toBe('D674C58C-DEFA-4F70-B7A2-27742230C0FC');
+    });
+
+    it('MUST: generates IFID when missing and emits error', async () => {
+      const source = ':: StoryTitle\nTest\n\n:: Start\nHello';
+      const result = await compileInline(source);
+      // Should have generated an IFID
+      expect(result.story.ifid).toMatch(/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/);
+      // Should have emitted an error
+      const ifidErrors = result.diagnostics.filter(
+        (d) => d.message.toLowerCase().includes('ifid') && d.level === 'error',
+      );
+      expect(ifidErrors.length).toBeGreaterThan(0);
+    });
+
+    it('MUST: IFID is a v4 UUID', async () => {
+      const result = await compileInline(minimalStory(':: Start\nHello'));
+      // v4 UUID format: 8-4-4-4-12 hex digits
+      expect(result.story.ifid).toMatch(/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/);
+    });
+  });
+
+  describe('format property', () => {
+    it('MUST: format is parsed from StoryData JSON', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube"}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.story.twine2.format).toBe('SugarCube');
+    });
+
+    it('MUST: format maps to tw-storydata format attribute', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube"}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.output).toContain('format="SugarCube"');
+    });
+  });
+
+  describe('format-version property', () => {
+    it('MUST: format-version is parsed from StoryData JSON', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube","format-version":"2.28.2"}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.story.twine2.formatVersion).toBe('2.28.2');
+    });
+
+    it('MUST: format-version maps to tw-storydata format-version attribute', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube","format-version":"2.28.2"}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.output).toContain('format-version="2.28.2"');
+    });
+  });
+
+  describe('start property', () => {
+    it('MUST: start specifies the starting passage name', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","start":"My Starting Passage"}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: My Starting Passage',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.story.twine2.start).toBe('My Starting Passage');
+    });
+
+    it('MUST: start maps to startnode via passagedata pid', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","start":"Begin"}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Other',
+        'Not start',
+        '',
+        ':: Begin',
+        'Start here',
+      ].join('\n');
+      const result = await compileInline(source);
+      // The startnode should reference the pid of "Begin", not "Other"
+      expect(result.output).toMatch(/startnode="2"/);
+    });
+  });
+
+  describe('tag-colors property', () => {
+    it('MUST: tag-colors is parsed from StoryData JSON', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","tag-colors":{"foo":"red","bar":"green"}}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.story.twine2.tagColors.get('foo')).toBe('red');
+      expect(result.story.twine2.tagColors.get('bar')).toBe('green');
+    });
+
+    it('MUST: tag-colors map to tw-tag elements', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","tag-colors":{"foo":"red","bar":"green"}}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.output).toContain('<tw-tag name="foo" color="red"></tw-tag>');
+      expect(result.output).toContain('<tw-tag name="bar" color="green"></tw-tag>');
+    });
+  });
+
+  describe('zoom property', () => {
+    it('MUST: zoom is parsed from StoryData JSON', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","zoom":0.25}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.story.twine2.zoom).toBe(0.25);
+    });
+
+    it('MUST: zoom maps to tw-storydata zoom attribute', async () => {
+      const source = [
+        ':: StoryData',
+        '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","zoom":0.25}',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.output).toMatch(/zoom="0\.25"/);
+    });
+  });
+
+  describe('StoryData JSON error handling', () => {
+    it('RECOMMENDED: emits warning on StoryData decode error and continues', async () => {
+      const source = [
+        ':: StoryData',
+        'not valid json at all',
+        '',
+        ':: StoryTitle',
+        'Test',
+        '',
+        ':: Start',
+        'Hello',
+      ].join('\n');
+      const result = await compileInline(source);
+      const errors = result.diagnostics.filter((d) => d.message.toLowerCase().includes('storydata'));
+      expect(errors.length).toBeGreaterThan(0);
+      // Should still produce output
+      expect(result.output.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Full StoryData example from spec', () => {
+    it('parses the complete StoryData example from the specification', async () => {
+      const source = [
+        ':: StoryData',
+        '{',
+        '   "ifid": "D674C58C-DEFA-4F70-B7A2-27742230C0FC",',
+        '   "format": "SugarCube",',
+        '   "format-version": "2.28.2",',
+        '   "start": "My Starting Passage",',
+        '   "tag-colors": {',
+        '     "bar": "green",',
+        '     "foo": "red",',
+        '     "qaz": "blue"',
+        '   },',
+        '   "zoom": 0.25',
+        '}',
+        '',
+        ':: StoryTitle',
+        'Spec Example Story',
+        '',
+        ':: My Starting Passage',
+        'Welcome!',
+      ].join('\n');
+      const result = await compileInline(source);
+      expect(result.story.ifid).toBe('D674C58C-DEFA-4F70-B7A2-27742230C0FC');
+      expect(result.story.twine2.format).toBe('SugarCube');
+      expect(result.story.twine2.formatVersion).toBe('2.28.2');
+      expect(result.story.twine2.start).toBe('My Starting Passage');
+      expect(result.story.twine2.tagColors.get('bar')).toBe('green');
+      expect(result.story.twine2.tagColors.get('foo')).toBe('red');
+      expect(result.story.twine2.tagColors.get('qaz')).toBe('blue');
+      expect(result.story.twine2.zoom).toBe(0.25);
+    });
+  });
+});
+
+// =============================================================================
+// Section: Special Passages — Start
+// "The default starting passage. May be overridden by the story metadata or
+//  compiler command."
+// =============================================================================
+
+describe('Special Passages — Start', () => {
+  it('MUST: "Start" passage is the default starting passage', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}',
+      '',
+      ':: StoryTitle',
+      'Test',
+      '',
+      ':: Start',
+      'Default start',
+    ].join('\n');
+    const result = await compileInline(source);
+    // The startnode should reference the Start passage
+    expect(result.output).toContain('startnode="1"');
+  });
+
+  it('MUST: start can be overridden by StoryData metadata', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","start":"Begin"}',
+      '',
+      ':: StoryTitle',
+      'Test',
+      '',
+      ':: Start',
+      'Not the start',
+      '',
+      ':: Begin',
+      'The real start',
+    ].join('\n');
+    const result = await compileInline(source);
+    // "Start" is pid 1, "Begin" is pid 2
+    expect(result.output).toContain('startnode="2"');
+  });
+
+  it('MUST: start can be overridden by compiler option', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}',
+      '',
+      ':: StoryTitle',
+      'Test',
+      '',
+      ':: Start',
+      'Not the start',
+      '',
+      ':: CustomStart',
+      'The real start',
+    ].join('\n');
+    const result = await compileInline(source, { startPassage: 'CustomStart' });
+    // "Start" is pid 1, "CustomStart" is pid 2
+    expect(result.output).toContain('startnode="2"');
+  });
+});
+
+// =============================================================================
+// Section: Special Tags — script
+// "Signifies that the passage's contents are JavaScript code."
+// "Maps to the <script type='text/twine-javascript'> node."
+// =============================================================================
+
+describe('Special Tags — script', () => {
+  it('MUST: passage with [script] tag maps to twine-javascript script node', async () => {
+    const source = minimalStory(':: Start\nHello\n\n:: MyScript [script]\nconsole.log("hello");');
+    const result = await compileInline(source);
+    expect(result.output).toContain('type="text/twine-javascript"');
+    expect(result.output).toContain('console.log("hello");');
+  });
+
+  it('MUST: script passage is NOT rendered as a regular tw-passagedata', async () => {
+    const source = minimalStory(':: Start\nHello\n\n:: MyScript [script]\nconsole.log("hello");');
+    const result = await compileInline(source);
+    expect(result.output).not.toContain('name="MyScript"');
+  });
+
+  it('combines multiple script passages', async () => {
+    const source = minimalStory(
+      ':: Start\nHello\n\n:: Script1 [script]\nvar a = 1;\n\n:: Script2 [script]\nvar b = 2;',
+    );
+    const result = await compileInline(source);
+    expect(result.output).toContain('var a = 1;');
+    expect(result.output).toContain('var b = 2;');
+  });
+});
+
+// =============================================================================
+// Section: Special Tags — stylesheet
+// "Signifies that the passage's contents are CSS style rules."
+// "Maps to the <style type='text/twine-css'> node."
+// =============================================================================
+
+describe('Special Tags — stylesheet', () => {
+  it('MUST: passage with [stylesheet] tag maps to twine-css style node', async () => {
+    const source = minimalStory(':: Start\nHello\n\n:: MyStyles [stylesheet]\nbody { color: red; }');
+    const result = await compileInline(source);
+    expect(result.output).toContain('type="text/twine-css"');
+    expect(result.output).toContain('body { color: red; }');
+  });
+
+  it('MUST: stylesheet passage is NOT rendered as a regular tw-passagedata', async () => {
+    const source = minimalStory(':: Start\nHello\n\n:: MyStyles [stylesheet]\nbody { color: red; }');
+    const result = await compileInline(source);
+    expect(result.output).not.toContain('name="MyStyles"');
+  });
+
+  it('combines multiple stylesheet passages', async () => {
+    const source = minimalStory(
+      ':: Start\nHello\n\n:: Style1 [stylesheet]\nbody { color: red; }\n\n:: Style2 [stylesheet]\np { margin: 0; }',
+    );
+    const result = await compileInline(source);
+    expect(result.output).toContain('body { color: red; }');
+    expect(result.output).toContain('p { margin: 0; }');
+  });
+});
+
+// =============================================================================
+// Section: Twine 2 HTML Output Structure
+// Validates that compiled output matches the tw-storydata / tw-passagedata
+// structure described in the spec.
+// =============================================================================
+
+describe('Twine 2 HTML Output Structure', () => {
+  it('MUST: output contains tw-storydata element', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toContain('<tw-storydata');
+    expect(result.output).toContain('</tw-storydata>');
+  });
+
+  it('MUST: tw-storydata has name attribute from StoryTitle', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toContain('name="Spec Test"');
+  });
+
+  it('MUST: tw-storydata has ifid attribute', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toContain('ifid="D674C58C-DEFA-4F70-B7A2-27742230C0FC"');
+  });
+
+  it('MUST: tw-storydata has format attribute', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube"}',
+      '',
+      ':: StoryTitle',
+      'Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileInline(source);
+    expect(result.output).toContain('format="SugarCube"');
+  });
+
+  it('MUST: tw-storydata has format-version attribute', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube","format-version":"2.28.2"}',
+      '',
+      ':: StoryTitle',
+      'Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileInline(source);
+    expect(result.output).toContain('format-version="2.28.2"');
+  });
+
+  it('MUST: tw-storydata has startnode attribute', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toMatch(/startnode="\d+"/);
+  });
+
+  it('MUST: tw-storydata has zoom attribute', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toMatch(/zoom="\d+(\.\d+)?"/);
+  });
+
+  it('MUST: regular passages become tw-passagedata elements', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello\n\n:: Room\nA room'));
+    expect(result.output).toContain('<tw-passagedata');
+    expect(result.output).toContain('name="Start"');
+    expect(result.output).toContain('name="Room"');
+  });
+
+  it('MUST: tw-passagedata has pid attribute', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toMatch(/pid="\d+"/);
+  });
+
+  it('MUST: tw-passagedata has name attribute', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toContain('name="Start"');
+  });
+
+  it('MUST: tw-passagedata has tags attribute', async () => {
+    const result = await compileInline(minimalStory(':: Start [tag1 tag2]\nHello'));
+    expect(result.output).toContain('tags="tag1 tag2"');
+  });
+
+  it('MUST: tw-passagedata has position attribute', async () => {
+    const result = await compileInline(minimalStory(':: Start {"position":"100,200"}\nHello'));
+    expect(result.output).toContain('position="100,200"');
+  });
+
+  it('MUST: tw-passagedata has size attribute', async () => {
+    const result = await compileInline(minimalStory(':: Start {"size":"200,100"}\nHello'));
+    expect(result.output).toContain('size="200,100"');
+  });
+
+  it('MUST: style element has type text/twine-css', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toContain('type="text/twine-css"');
+  });
+
+  it('MUST: script element has type text/twine-javascript', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toContain('type="text/twine-javascript"');
+  });
+
+  it('MUST: StoryTitle passage is NOT rendered as tw-passagedata', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).not.toContain('name="StoryTitle"');
+  });
+
+  it('MUST: StoryData passage is NOT rendered as tw-passagedata', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).not.toContain('name="StoryData"');
+  });
+});
+
+// =============================================================================
+// Section: Passage Header — Spec Examples
+// Tests the exact examples given in the specification.
+// =============================================================================
+
+describe('Spec Examples', () => {
+  it('Example: minimal working example', () => {
+    const { passages } = parseTwee(':: An overgrown path\n');
+    expect(passages).toHaveLength(1);
+    expect(passages[0]!.name).toBe('An overgrown path');
+  });
+
+  it('Example: with only optional tags', () => {
+    const { passages } = parseTwee(':: An overgrown path [forest spooky]\n');
+    expect(passages[0]!.name).toBe('An overgrown path');
+    expect(passages[0]!.tags).toEqual(['forest', 'spooky']);
+  });
+
+  it('Example: with only optional metadata', () => {
+    const { passages } = parseTwee(':: An overgrown path {"position":"600,400","size":"100,200"}\n');
+    expect(passages[0]!.name).toBe('An overgrown path');
+    expect(passages[0]!.metadata).toEqual({ position: '600,400', size: '100,200' });
+  });
+
+  it('Example: with both optional tags and metadata', () => {
+    const { passages } = parseTwee(':: An overgrown path [forest spooky] {"position":"600,400","size":"100,200"}\n');
+    expect(passages[0]!.name).toBe('An overgrown path');
+    expect(passages[0]!.tags).toEqual(['forest', 'spooky']);
+    expect(passages[0]!.metadata).toEqual({ position: '600,400', size: '100,200' });
+  });
+});
+
+// =============================================================================
+// Section: Prolog / text before first passage
+// "It is recommended Twee files are written in UTF-8."
+// =============================================================================
+
+describe('Prolog and Encoding', () => {
+  it('ignores text before the first passage header (prolog)', () => {
+    const { passages } = parseTwee('This is some introductory text\n\n:: Start\nContent');
+    expect(passages).toHaveLength(1);
+    expect(passages[0]!.name).toBe('Start');
+  });
+
+  it('handles empty file gracefully', () => {
+    const { passages, diagnostics } = parseTwee('');
+    expect(passages).toHaveLength(0);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('handles file with only prolog (no passages)', () => {
+    const { passages } = parseTwee('Just some text without any passage headers');
+    expect(passages).toHaveLength(0);
+  });
+
+  it('handles UTF-8 content in passage names', () => {
+    const { passages } = parseTwee(':: Übersicht\nInhalt');
+    expect(passages[0]!.name).toBe('Übersicht');
+  });
+
+  it('handles UTF-8 content in passage body', () => {
+    const { passages } = parseTwee(':: Start\n日本語テキスト');
+    expect(passages[0]!.text).toBe('日本語テキスト');
+  });
+
+  it('handles UTF-8 content in tags', () => {
+    const { passages } = parseTwee(':: Start [étiquette]\nContent');
+    expect(passages[0]!.tags).toEqual(['étiquette']);
+  });
+});
+
+// =============================================================================
+// Section: Multiple source files
+// The spec implies a story is composed from one or more Twee files.
+// =============================================================================
+
+describe('Multiple Source Files', () => {
+  it('compiles from multiple inline sources', async () => {
+    const result = await compileInline(':: Start\nHello', {
+      sources: [
+        {
+          filename: 'storydata.tw',
+          content: ':: StoryData\n{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}\n\n:: StoryTitle\nMulti File',
+        },
+        {
+          filename: 'passages.tw',
+          content: ':: Start\nHello from passages',
+        },
+      ],
+    });
+    expect(result.story.name).toBe('Multi File');
+    expect(result.output).toContain('Hello from passages');
+  });
+
+  it('compiles from file paths', async () => {
+    const result = await compile({
+      sources: [join(FIXTURES_DIR, 'minimal.tw')],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+    });
+    expect(result.output).toContain('Minimal Story');
+    expect(result.stats.passages).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// Section: Edge Cases and Robustness
+// =============================================================================
+
+describe('Edge Cases', () => {
+  it('handles passage name with only spaces after :: (error)', () => {
+    const { diagnostics } = parseTwee('::    \nContent');
+    expect(diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it('handles multiple consecutive passage headers', () => {
+    const { passages } = parseTwee(':: A\n:: B\n:: C\nContent');
+    expect(passages).toHaveLength(3);
+    expect(passages[0]!.name).toBe('A');
+    expect(passages[1]!.name).toBe('B');
+    expect(passages[2]!.name).toBe('C');
+    expect(passages[2]!.text).toBe('Content');
+  });
+
+  it('handles passage with very long name', () => {
+    const longName = 'A'.repeat(500);
+    const { passages } = parseTwee(`:: ${longName}\nContent`);
+    expect(passages[0]!.name).toBe(longName);
+  });
+
+  it('handles passage with many tags', () => {
+    const tags = Array.from({ length: 50 }, (_, i) => `tag${i}`);
+    const { passages } = parseTwee(`:: Room [${tags.join(' ')}]\nContent`);
+    expect(passages[0]!.tags).toHaveLength(50);
+  });
+
+  it('handles passage content with special characters', () => {
+    const { passages } = parseTwee(':: Start\n<html>&amp;"quotes"</html>');
+    expect(passages[0]!.text).toContain('<html>');
+    expect(passages[0]!.text).toContain('&amp;');
+  });
+
+  it('handles Windows-style line endings (\\r\\n)', () => {
+    const { passages } = parseTwee(':: Start\r\nContent line 1\r\nContent line 2\r\n\r\n:: Second\r\nMore');
+    expect(passages).toHaveLength(2);
+    expect(passages[0]!.name).toBe('Start');
+  });
+
+  it('handles metadata with nested JSON objects', () => {
+    const { passages } = parseTwee(':: Room {"position":"100,100","size":"200,100"}\nContent');
+    expect(passages[0]!.metadata?.position).toBe('100,100');
+    expect(passages[0]!.metadata?.size).toBe('200,100');
+  });
+
+  it('MUST: passage header is on a single line', () => {
+    // Metadata cannot span multiple lines (unterminated)
+    const { diagnostics } = parseTwee(':: Room {"position":\n"100,100"}\nContent');
+    expect(diagnostics.length).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// Section: Twee 3 Output (roundtrip)
+// When outputting Twee 3, the spec format should be preserved.
+// =============================================================================
+
+describe('Twee 3 Output Format', () => {
+  it('outputs passages with :: header', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'), {
+      outputMode: 'twee3',
+    });
+    expect(result.output).toContain(':: Start');
+  });
+
+  it('outputs tags in square brackets', async () => {
+    const result = await compileInline(minimalStory(':: Room [forest spooky]\nContent'), { outputMode: 'twee3' });
+    expect(result.output).toContain(':: Room [forest spooky]');
+  });
+
+  it('outputs metadata as inline JSON', async () => {
+    const result = await compileInline(minimalStory(':: Room {"position":"100,100","size":"200,100"}\nContent'), {
+      outputMode: 'twee3',
+    });
+    expect(result.output).toContain('"position":"100,100"');
+    expect(result.output).toContain('"size":"200,100"');
+  });
+
+  it('outputs StoryData as pretty-printed JSON (RECOMMENDED)', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'), {
+      outputMode: 'twee3',
+    });
+    // StoryData should be in the output and be pretty-printed (indented)
+    expect(result.output).toContain(':: StoryData');
+    expect(result.output).toContain('"ifid"');
+  });
+
+  it('escapes passage names with metacharacters in Twee 3 output', async () => {
+    // Compile a passage whose name contains [ and check the twee3 output escapes it
+    const source = minimalStory('');
+    const result = await compile({
+      sources: [
+        {
+          filename: 'test.tw',
+          content: source + ':: Start\nHello',
+        },
+      ],
+      outputMode: 'twee3',
+    });
+    // The output should contain proper twee3 format
+    expect(result.output).toContain(':: Start');
+  });
+});
+
+// =============================================================================
+// Section: Diagnostics and Error Reporting
+// The spec calls for warnings in certain situations.
+// =============================================================================
+
+describe('Diagnostics and Error Reporting', () => {
+  it('collects errors without crashing', async () => {
+    const result = await compileInline(':: Test [unclosed\nContent', { outputMode: 'twee3' });
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it('diagnostics have level (warning or error)', () => {
+    const { diagnostics } = parseTwee(':: Test [unclosed\nContent');
+    expect(diagnostics[0]!.level).toMatch(/^(warning|error)$/);
+  });
+
+  it('diagnostics have message', () => {
+    const { diagnostics } = parseTwee(':: Test [unclosed\nContent');
+    expect(diagnostics[0]!.message.length).toBeGreaterThan(0);
+  });
+
+  it('diagnostics include file info when filename is provided', () => {
+    const { diagnostics } = parseTwee(':: Test [unclosed\nContent', { filename: 'my-story.tw' });
+    expect(diagnostics[0]!.file).toBe('my-story.tw');
+  });
+
+  it('diagnostics include line number', () => {
+    const { diagnostics } = parseTwee(':: Test [unclosed\nContent');
+    expect(diagnostics[0]!.line).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// Section: IFID Validation
+// "Twine 2 uses v4 (random) UUIDs, using only capital letters"
+// =============================================================================
+
+describe('IFID Compliance', () => {
+  it('MUST: IFIDs are uppercase UUIDs', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.story.ifid).toMatch(/^[0-9A-F-]+$/);
+  });
+
+  it('MUST: auto-generated IFIDs are valid v4 UUIDs', async () => {
+    const source = ':: StoryTitle\nTest\n\n:: Start\nHello';
+    const result = await compileInline(source);
+    // v4 UUID: xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx
+    expect(result.story.ifid).toMatch(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/);
+  });
+
+  it('MUST: validates IFID format and reports error for invalid IFID', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"not-a-valid-uuid"}',
+      '',
+      ':: StoryTitle',
+      'Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileInline(source);
+    const ifidErrors = result.diagnostics.filter(
+      (d) => d.message.toLowerCase().includes('ifid') || d.message.toLowerCase().includes('uuid'),
+    );
+    expect(ifidErrors.length).toBeGreaterThan(0);
+  });
+
+  it('MUST: HTML output includes UUID comment', async () => {
+    const result = await compileInline(minimalStory(':: Start\nHello'));
+    expect(result.output).toContain('<!-- UUID://');
+    expect(result.output).toContain('D674C58C-DEFA-4F70-B7A2-27742230C0FC');
+  });
+});
+
+// =============================================================================
+// Section: Complete Integration — Real Fixture Files
+// =============================================================================
+
+describe('Integration — Fixture Files', () => {
+  it('compiles minimal.tw correctly', async () => {
+    const result = await compile({
+      sources: [join(FIXTURES_DIR, 'minimal.tw')],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+    });
+    expect(result.story.name).toBe('Minimal Story');
+    expect(result.story.ifid).toBe('D674C58C-DEFA-4F70-B7A2-27742230C0FC');
+    expect(result.output).toContain('Hello, world!');
+  });
+
+  it('compiles multi-passage.tw with tags', async () => {
+    const result = await compile({
+      sources: [join(FIXTURES_DIR, 'multi-passage.tw')],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+    });
+    expect(result.output).toContain('name="Room"');
+    expect(result.output).toContain('tags="location"');
+    expect(result.output).toContain('tags="location hidden"');
+  });
+
+  it('compiles storydata.tw with full metadata', async () => {
+    const result = await compile({
+      sources: [join(FIXTURES_DIR, 'storydata.tw')],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+    });
+    expect(result.story.twine2.format).toBe('SugarCube');
+    expect(result.story.twine2.formatVersion).toBe('2.37.3');
+    expect(result.story.twine2.start).toBe('Begin');
+    expect(result.output).toContain('position="100,100"');
+    expect(result.output).toContain('size="200,100"');
+  });
+});

--- a/specs/twine1-htmloutput-spec.test.ts
+++ b/specs/twine1-htmloutput-spec.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Twine 1 HTML Output Specification Compliance Tests (v1.0)
+ *
+ * Tests twee-ts against every requirement in the Twine 1 HTML Output Specification:
+ * https://github.com/iftechfoundation/twine-specs/blob/master/twine-1-htmloutput-doc.md
+ *
+ * Each describe block corresponds to a section of the spec.
+ *
+ * Note: The companion Twine 1 TWS Output spec (twine-1-twsoutput.md) describes a
+ * Python 2 pickle binary serialisation format used by the Twine 1 GUI editor.
+ * twee-ts does not produce TWS output, so no conformance tests are provided for it.
+ */
+import { describe, it, expect } from 'vitest';
+import { compile } from '../src/compiler.js';
+import type { CompileResult } from '../src/types.js';
+
+/** Helper: compile inline twee source to Twine 1 archive output. */
+async function compileToArchive(content: string): Promise<CompileResult> {
+  return compile({
+    sources: [{ filename: 'spec-test.tw', content }],
+    outputMode: 'twine1-archive',
+  });
+}
+
+/** Helper: build a minimal valid twee source with StoryTitle. */
+function minimalStory(passages: string): string {
+  return [':: StoryTitle', 'Spec Test', '', passages].join('\n');
+}
+
+/** Extract the <div id="storeArea" ...>...</div> chunk from compiled output. */
+function extractStoreArea(html: string): string {
+  const match = html.match(/<div id="storeArea"[\s\S]*?<\/div>\s*$/);
+  expect(match, 'output must contain <div id="storeArea">').not.toBeNull();
+  return match![0];
+}
+
+/** Extract all tiddler <div> elements as strings. */
+function tiddlerElements(html: string): string[] {
+  return [...html.matchAll(/<div tiddler=[^>]*>[\s\S]*?<\/div>/g)].map((m) => m[0]);
+}
+
+/** Extract an attribute value from an HTML element string. */
+function attr(element: string, name: string): string | null {
+  const re = new RegExp(`${name}="([^"]*)"`, 'i');
+  const match = element.match(re);
+  return match ? match[1] : null;
+}
+
+/** Extract text content between the opening and closing tags. */
+function textContent(element: string): string {
+  const match = element.match(/>([^]*)<\/div>/);
+  return match ? match[1] : '';
+}
+
+// =============================================================================
+// §1 — Root Structure: <div id="storeArea">
+// =============================================================================
+describe('Twine 1 HTML Output Spec — Root Structure', () => {
+  it('output contains a <div id="storeArea"> root element', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    expect(result.output).toContain('<div id="storeArea"');
+    expect(result.output).toContain('</div>');
+  });
+
+  it('storeArea has data-size attribute matching the passage count', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: Second', 'World'].join('\n'));
+    const result = await compileToArchive(source);
+    const storeArea = extractStoreArea(result.output);
+    const size = attr(storeArea, 'data-size');
+    expect(size).not.toBeNull();
+    // StoryTitle is included in passage count for Twine 1
+    const tiddlers = tiddlerElements(result.output);
+    expect(size).toBe(String(tiddlers.length));
+  });
+
+  it('storeArea has the hidden attribute', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const match = result.output.match(/<div id="storeArea"[^>]*>/);
+    expect(match).not.toBeNull();
+    expect(match![0]).toContain('hidden');
+  });
+
+  it('passages are child <div> elements with tiddler attribute', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const tiddlers = tiddlerElements(result.output);
+    expect(tiddlers.length).toBeGreaterThan(0);
+    for (const t of tiddlers) {
+      expect(t).toMatch(/^<div tiddler=/);
+    }
+  });
+});
+
+// =============================================================================
+// §2 — Passage Attributes
+// =============================================================================
+describe('Twine 1 HTML Output Spec — Passage Attributes', () => {
+  it('tiddler attribute: required, matches passage name', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(startTiddler).toBeDefined();
+  });
+
+  it('tags attribute: required, space-separated tag list', async () => {
+    const source = minimalStory(':: Start [alpha beta gamma]\nHello');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(startTiddler).toBeDefined();
+    expect(attr(startTiddler!, 'tags')).toBe('alpha beta gamma');
+  });
+
+  it('tags attribute: empty string when no tags', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(startTiddler).toBeDefined();
+    expect(attr(startTiddler!, 'tags')).toBe('');
+  });
+
+  it('twine-position attribute: required, comma-separated X,Y', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(startTiddler).toBeDefined();
+    const position = attr(startTiddler!, 'twine-position');
+    expect(position).not.toBeNull();
+    expect(position).toMatch(/^\d+,\d+$/);
+  });
+
+  it('twine-position attribute: reflects explicit metadata position', async () => {
+    const source = minimalStory(':: Start {"position":"250,300"}\nHello');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(startTiddler).toBeDefined();
+    expect(attr(startTiddler!, 'twine-position')).toBe('250,300');
+  });
+
+  it('tiddler name with special characters is attribute-escaped', async () => {
+    const source = minimalStory(':: A "B" & C\nHello');
+    const result = await compileToArchive(source);
+    const output = result.output;
+    expect(output).toContain('tiddler="A &quot;B&quot; &amp; C"');
+  });
+});
+
+// =============================================================================
+// §3 — Content Encoding (Tiddler Escaping)
+// =============================================================================
+describe('Twine 1 HTML Output Spec — Content Encoding', () => {
+  it('& is encoded as &amp;', async () => {
+    const source = minimalStory(':: Start\nA & B');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(textContent(startTiddler!)).toContain('A &amp; B');
+  });
+
+  it('< is encoded as &lt;', async () => {
+    const source = minimalStory(':: Start\nA < B');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(textContent(startTiddler!)).toContain('A &lt; B');
+  });
+
+  it('> is encoded as &gt;', async () => {
+    const source = minimalStory(':: Start\nA > B');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(textContent(startTiddler!)).toContain('A &gt; B');
+  });
+
+  it('" is encoded as &quot;', async () => {
+    const source = minimalStory(':: Start\nSay "hello"');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(textContent(startTiddler!)).toContain('Say &quot;hello&quot;');
+  });
+
+  it('backslash is encoded as \\s', async () => {
+    const source = minimalStory(':: Start\npath\\to\\file');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(textContent(startTiddler!)).toContain('path\\sto\\sfile');
+  });
+
+  it('tab is encoded as \\t', async () => {
+    const source = minimalStory(':: Start\ncol1\tcol2');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(textContent(startTiddler!)).toContain('col1\\tcol2');
+  });
+
+  it('newline is encoded as \\n', async () => {
+    const source = minimalStory(':: Start\nLine 1\nLine 2');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(textContent(startTiddler!)).toContain('Line 1\\nLine 2');
+  });
+
+  it('combined encoding: all special characters in one passage', async () => {
+    const source = minimalStory(':: Start\n<a href="x">&\\path\ttab');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    const content = textContent(startTiddler!);
+    expect(content).toContain('&lt;a href=&quot;x&quot;&gt;');
+    expect(content).toContain('&amp;');
+    expect(content).toContain('\\spath');
+    expect(content).toContain('\\ttab');
+  });
+
+  it('empty passage produces empty tiddler content', async () => {
+    const source = minimalStory(':: Start\n');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(startTiddler).toBeDefined();
+    expect(textContent(startTiddler!)).toBe('');
+  });
+});
+
+// =============================================================================
+// §4 — Special Passages (Story Metadata)
+// =============================================================================
+describe('Twine 1 HTML Output Spec — Special Passages', () => {
+  it('StoryTitle passage is included as a tiddler', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const tiddlers = tiddlerElements(result.output);
+    const titleTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'StoryTitle');
+    expect(titleTiddler).toBeDefined();
+  });
+
+  it('StorySettings passage is included as a tiddler', async () => {
+    const source = [
+      ':: StoryTitle',
+      'Test Story',
+      '',
+      ':: StorySettings',
+      'undo:on',
+      'bookmark:off',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const settingsTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'StorySettings');
+    expect(settingsTiddler).toBeDefined();
+  });
+
+  it('StoryAuthor passage is included as a tiddler', async () => {
+    const source = [':: StoryTitle', 'Test Story', '', ':: StoryAuthor', 'Test Author', '', ':: Start', 'Hello'].join(
+      '\n',
+    );
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const authorTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'StoryAuthor');
+    expect(authorTiddler).toBeDefined();
+  });
+
+  it('StorySubtitle passage is included as a tiddler', async () => {
+    const source = [':: StoryTitle', 'Test Story', '', ':: StorySubtitle', 'A Subtitle', '', ':: Start', 'Hello'].join(
+      '\n',
+    );
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const subtitleTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'StorySubtitle');
+    expect(subtitleTiddler).toBeDefined();
+  });
+});
+
+// =============================================================================
+// §5 — Twine.private Filtering
+// =============================================================================
+describe('Twine 1 HTML Output Spec — Twine.private Filtering', () => {
+  it('passages tagged Twine.private are excluded from output', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: Hidden [Twine.private]', 'Secret stuff'].join('\n'));
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const names = tiddlers.map((t) => attr(t, 'tiddler'));
+    expect(names).not.toContain('Hidden');
+  });
+
+  it('Twine.private passages are not counted in data-size', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: Hidden [Twine.private]', 'Secret'].join('\n'));
+    const result = await compileToArchive(source);
+    const storeArea = extractStoreArea(result.output);
+    const size = attr(storeArea, 'data-size');
+    const tiddlers = tiddlerElements(result.output);
+    expect(size).toBe(String(tiddlers.length));
+  });
+});
+
+// =============================================================================
+// §6 — Passage Count Accuracy
+// =============================================================================
+describe('Twine 1 HTML Output Spec — Passage Count', () => {
+  it('data-size reflects the actual number of tiddler elements', async () => {
+    const source = minimalStory(
+      [':: Start', 'Hello', '', ':: Chapter 1', 'Content', '', ':: Chapter 2', 'More'].join('\n'),
+    );
+    const result = await compileToArchive(source);
+    const storeArea = extractStoreArea(result.output);
+    const size = attr(storeArea, 'data-size');
+    const tiddlers = tiddlerElements(result.output);
+    expect(Number(size)).toBe(tiddlers.length);
+  });
+
+  it('single passage story has correct data-size', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const storeArea = extractStoreArea(result.output);
+    const size = attr(storeArea, 'data-size');
+    const tiddlers = tiddlerElements(result.output);
+    expect(Number(size)).toBe(tiddlers.length);
+  });
+});
+
+// =============================================================================
+// §7 — Multiple Passages
+// =============================================================================
+describe('Twine 1 HTML Output Spec — Multiple Passages', () => {
+  it('all non-private passages appear as tiddler elements', async () => {
+    const source = minimalStory(
+      [':: Start', 'Hello', '', ':: Room1', 'First room', '', ':: Room2', 'Second room'].join('\n'),
+    );
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const names = tiddlers.map((t) => attr(t, 'tiddler'));
+    expect(names).toContain('Start');
+    expect(names).toContain('Room1');
+    expect(names).toContain('Room2');
+  });
+
+  it('each tiddler has unique auto-generated position when not specified', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: Room1', 'First', '', ':: Room2', 'Second'].join('\n'));
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const positions = tiddlers.map((t) => attr(t, 'twine-position'));
+    // All positions should be valid
+    for (const pos of positions) {
+      expect(pos).toMatch(/^\d+,\d+$/);
+    }
+    // All positions should be unique
+    expect(new Set(positions).size).toBe(positions.length);
+  });
+});
+
+// =============================================================================
+// §8 — IFID Comment
+// =============================================================================
+describe('Twine 1 HTML Output Spec — IFID', () => {
+  it('archive output does not include IFID comment (only full HTML does)', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}',
+      '',
+      ':: StoryTitle',
+      'IFID Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    // IFID comment is only added in full HTML output, not archive
+    // Archive should still be valid without it
+    expect(result.output).toContain('<div id="storeArea"');
+  });
+});
+
+// =============================================================================
+// §9 — StorySettings Values
+// =============================================================================
+describe('Twine 1 HTML Output Spec — StorySettings', () => {
+  it('StorySettings with key:value pairs is stored in a tiddler', async () => {
+    const source = [
+      ':: StoryTitle',
+      'Settings Test',
+      '',
+      ':: StorySettings',
+      'undo:on',
+      'bookmark:off',
+      'hash:on',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const settingsTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'StorySettings');
+    expect(settingsTiddler).toBeDefined();
+    // Content should contain the settings (tiddler-escaped)
+    const content = textContent(settingsTiddler!);
+    expect(content).toContain('undo');
+    expect(content).toContain('bookmark');
+  });
+
+  it('StorySettings values are parsed into story metadata', async () => {
+    const source = [
+      ':: StoryTitle',
+      'Settings Test',
+      '',
+      ':: StorySettings',
+      'undo:on',
+      'jquery:on',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    expect(result.story.twine1.settings.get('undo')).toBe('on');
+    expect(result.story.twine1.settings.get('jquery')).toBe('on');
+  });
+});
+
+// =============================================================================
+// §10 — Tag Handling
+// =============================================================================
+describe('Twine 1 HTML Output Spec — Tag Handling', () => {
+  it('multiple tags are space-separated in the tags attribute', async () => {
+    const source = minimalStory(':: Start [tag1 tag2 tag3]\nHello');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(attr(startTiddler!, 'tags')).toBe('tag1 tag2 tag3');
+  });
+
+  it('tags with special characters are attribute-escaped', async () => {
+    const source = minimalStory(':: Start [tag&one]\nHello');
+    const result = await compileToArchive(source);
+    const tiddlers = tiddlerElements(result.output);
+    const startTiddler = tiddlers.find((t) => attr(t, 'tiddler') === 'Start');
+    expect(attr(startTiddler!, 'tags')).toContain('&amp;');
+  });
+});

--- a/specs/twine2-archive-spec.test.ts
+++ b/specs/twine2-archive-spec.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Twine 2 Archive Specification Compliance Tests (v1.0.0)
+ *
+ * Tests twee-ts against every requirement in the Twine 2 Archive Specification:
+ * https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-archive-spec.md
+ *
+ * The archive format is a collection of one or more stories, each following
+ * the Twine 2 HTML Output Specification, without outer HTML wrapping.
+ */
+import { describe, it, expect } from 'vitest';
+import { compile } from '../src/compiler.js';
+import type { CompileResult } from '../src/types.js';
+
+/** Helper: compile inline twee source to Twine 2 archive. */
+async function compileToArchive(content: string): Promise<CompileResult> {
+  return compile({
+    sources: [{ filename: 'spec-test.tw', content }],
+    outputMode: 'twine2-archive',
+  });
+}
+
+/** Helper: build a minimal valid twee source. */
+function minimalStory(name: string, passages: string): string {
+  return [
+    ':: StoryData',
+    `{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}`,
+    '',
+    ':: StoryTitle',
+    name,
+    '',
+    passages,
+  ].join('\n');
+}
+
+// =============================================================================
+// §1 — Archive Format: Structure
+// =============================================================================
+describe('Twine 2 Archive Spec — Structure', () => {
+  it('archive output contains <tw-storydata> element', async () => {
+    const result = await compileToArchive(minimalStory('Archive Test', ':: Start\nHello'));
+    expect(result.output).toContain('<tw-storydata');
+    expect(result.output).toContain('</tw-storydata>');
+  });
+
+  it('archive output does NOT contain outer <html> wrapping', async () => {
+    const result = await compileToArchive(minimalStory('Archive Test', ':: Start\nHello'));
+    expect(result.output).not.toContain('<html>');
+    expect(result.output).not.toContain('</html>');
+    expect(result.output).not.toContain('<head>');
+    expect(result.output).not.toContain('<body>');
+  });
+
+  it('archive output is the raw tw-storydata chunk followed by newline', async () => {
+    const result = await compileToArchive(minimalStory('Archive Test', ':: Start\nHello'));
+    // Should end with </tw-storydata> followed by a newline
+    expect(result.output.trimEnd()).toMatch(/<\/tw-storydata>$/);
+  });
+});
+
+// =============================================================================
+// §2 — Archive Follows HTML Output Spec
+// =============================================================================
+describe('Twine 2 Archive Spec — Follows HTML Output Specification', () => {
+  it('archive contains all required <tw-storydata> attributes', async () => {
+    const result = await compileToArchive(minimalStory('Archive Attrs', ':: Start\nHello'));
+    const tag = result.output.match(/<tw-storydata[^>]*>/);
+    expect(tag).not.toBeNull();
+    const tagStr = tag![0];
+    // Required attributes per HTML output spec
+    expect(tagStr).toMatch(/name="/);
+    expect(tagStr).toMatch(/ifid="/);
+    expect(tagStr).toMatch(/startnode="/);
+  });
+
+  it('archive <tw-storydata> has hidden attribute', async () => {
+    const result = await compileToArchive(minimalStory('Hidden Test', ':: Start\nHello'));
+    const tag = result.output.match(/<tw-storydata[^>]*>/);
+    expect(tag).not.toBeNull();
+    expect(tag![0]).toContain('hidden');
+  });
+
+  it('archive contains <style> element inside <tw-storydata>', async () => {
+    const result = await compileToArchive(minimalStory('Style Test', ':: Start\nHello'));
+    const chunk = result.output.match(/<tw-storydata[\s\S]*?<\/tw-storydata>/);
+    expect(chunk).not.toBeNull();
+    expect(chunk![0]).toContain('<style');
+    expect(chunk![0]).toContain('id="twine-user-stylesheet"');
+    expect(chunk![0]).toContain('type="text/twine-css"');
+  });
+
+  it('archive contains <script> element inside <tw-storydata>', async () => {
+    const result = await compileToArchive(minimalStory('Script Test', ':: Start\nHello'));
+    const chunk = result.output.match(/<tw-storydata[\s\S]*?<\/tw-storydata>/);
+    expect(chunk).not.toBeNull();
+    expect(chunk![0]).toContain('<script');
+    expect(chunk![0]).toContain('id="twine-user-script"');
+    expect(chunk![0]).toContain('type="text/twine-javascript"');
+  });
+
+  it('archive contains <tw-passagedata> for each story passage', async () => {
+    const source = minimalStory(
+      'Passages Test',
+      [':: Start', 'Hello', '', ':: Second', 'World', '', ':: Third', 'Foo'].join('\n'),
+    );
+    const result = await compileToArchive(source);
+    const passages = [...result.output.matchAll(/<tw-passagedata/g)];
+    expect(passages.length).toBe(3);
+  });
+
+  it('archive passage content is HTML-escaped', async () => {
+    const source = minimalStory('Escape Test', ':: Start\nA & B < C > D');
+    const result = await compileToArchive(source);
+    expect(result.output).toContain('A &amp; B &lt; C &gt; D');
+  });
+
+  it('archive contains <tw-tag> when tag-colors are defined', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","tag-colors":{"scene":"green"}}',
+      '',
+      ':: StoryTitle',
+      'Tag Color Archive',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    expect(result.output).toContain('<tw-tag');
+    expect(result.output).toMatch(/name="scene"/);
+    expect(result.output).toMatch(/color="green"/);
+  });
+});
+
+// =============================================================================
+// §3 — Archive: Story Metadata Preservation
+// =============================================================================
+describe('Twine 2 Archive Spec — Metadata Preservation', () => {
+  it('story name is preserved in archive', async () => {
+    const result = await compileToArchive(minimalStory('My Great Story', ':: Start\nHello'));
+    expect(result.output).toContain('name="My Great Story"');
+  });
+
+  it('IFID is preserved in archive', async () => {
+    const result = await compileToArchive(minimalStory('IFID Test', ':: Start\nHello'));
+    expect(result.output).toContain('ifid="D674C58C-DEFA-4F70-B7A2-27742230C0FC"');
+  });
+
+  it('format and format-version are preserved in archive', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"Harlowe","format-version":"3.3.7"}',
+      '',
+      ':: StoryTitle',
+      'Format Preservation',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    expect(result.output).toContain('format="Harlowe"');
+    expect(result.output).toContain('format-version="3.3.7"');
+  });
+
+  it('zoom value is preserved in archive', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","zoom":1.2}',
+      '',
+      ':: StoryTitle',
+      'Zoom Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    expect(result.output).toContain('zoom="1.2"');
+  });
+
+  it('creator and creator-version are present in archive', async () => {
+    const result = await compileToArchive(minimalStory('Creator Test', ':: Start\nHello'));
+    expect(result.output).toMatch(/creator="/);
+    expect(result.output).toMatch(/creator-version="/);
+  });
+});
+
+// =============================================================================
+// §4 — Archive: Passage Data Completeness
+// =============================================================================
+describe('Twine 2 Archive Spec — Passage Data', () => {
+  it('passage pid, name, tags, position, and size attributes are present', async () => {
+    const source = minimalStory('Attr Test', ':: Start [tag1 tag2] {"position":"100,200","size":"150,100"}\nHello');
+    const result = await compileToArchive(source);
+    const passage = result.output.match(/<tw-passagedata[^>]*>/);
+    expect(passage).not.toBeNull();
+    const p = passage![0];
+    expect(p).toMatch(/pid="/);
+    expect(p).toMatch(/name="Start"/);
+    expect(p).toMatch(/tags="tag1 tag2"/);
+    expect(p).toMatch(/position="100,200"/);
+    expect(p).toMatch(/size="150,100"/);
+  });
+
+  it('special passages (StoryTitle, StoryData) are excluded from archive passages', async () => {
+    const result = await compileToArchive(minimalStory('Exclusion Test', ':: Start\nHello'));
+    expect(result.output).not.toMatch(/name="StoryTitle"/);
+    expect(result.output).not.toMatch(/name="StoryData"/);
+  });
+
+  it('script/stylesheet passages are excluded from archive passages', async () => {
+    const source = minimalStory(
+      'Tag Exclusion',
+      [':: Start', 'Hello', '', ':: JS [script]', 'code', '', ':: CSS [stylesheet]', 'styles'].join('\n'),
+    );
+    const result = await compileToArchive(source);
+    // These should NOT appear as tw-passagedata
+    const passageMatches = [...result.output.matchAll(/name="(JS|CSS)"/g)];
+    expect(passageMatches.length).toBe(0);
+    // But their content should be in script/style elements
+    expect(result.output).toContain('code');
+    expect(result.output).toContain('styles');
+  });
+});
+
+// =============================================================================
+// §5 — Archive: UUID Comment
+// =============================================================================
+describe('Twine 2 Archive Spec — UUID Comment', () => {
+  it('archive output includes UUID comment before <tw-storydata>', async () => {
+    const result = await compileToArchive(minimalStory('UUID Test', ':: Start\nHello'));
+    // twee-ts outputs <!-- UUID://IFID// --> before <tw-storydata>
+    expect(result.output).toMatch(/<!-- UUID:\/\/.*\/\/ -->/);
+  });
+
+  it('UUID comment contains the story IFID', async () => {
+    const result = await compileToArchive(minimalStory('UUID IFID', ':: Start\nHello'));
+    expect(result.output).toContain('UUID://D674C58C-DEFA-4F70-B7A2-27742230C0FC//');
+  });
+});

--- a/specs/twine2-htmloutput-spec.test.ts
+++ b/specs/twine2-htmloutput-spec.test.ts
@@ -1,0 +1,780 @@
+/**
+ * Twine 2 HTML Output Specification Compliance Tests (v1.0.2)
+ *
+ * Tests twee-ts against every requirement in the Twine 2 HTML Output Specification:
+ * https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-htmloutput-spec.md
+ *
+ * Each describe block corresponds to a section of the spec.
+ */
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { compile } from '../src/compiler.js';
+import type { CompileResult } from '../src/types.js';
+
+const FIXTURES_DIR = join(__dirname, '..', 'test', 'fixtures');
+const FORMAT_DIR = join(FIXTURES_DIR, 'storyformats');
+
+/** Helper: compile inline twee source to Twine 2 HTML. */
+async function compileToHTML(content: string, options: Record<string, unknown> = {}): Promise<CompileResult> {
+  return compile({
+    sources: [{ filename: 'spec-test.tw', content }],
+    formatId: 'test-format-1',
+    formatPaths: [FORMAT_DIR],
+    useTweegoPath: false,
+    ...options,
+  });
+}
+
+/** Helper: compile inline twee source to Twine 2 archive (no format needed). */
+async function compileToArchive(content: string): Promise<CompileResult> {
+  return compile({
+    sources: [{ filename: 'spec-test.tw', content }],
+    outputMode: 'twine2-archive',
+  });
+}
+
+/** Helper: build a minimal valid twee source with StoryData and StoryTitle. */
+function minimalStory(passages: string): string {
+  return [
+    ':: StoryData',
+    '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}',
+    '',
+    ':: StoryTitle',
+    'Spec Test',
+    '',
+    passages,
+  ].join('\n');
+}
+
+/**
+ * Extract the <tw-storydata ...>...</tw-storydata> chunk from compiled output.
+ * Works for both full HTML and archive output.
+ */
+function extractStoryData(html: string): string {
+  const match = html.match(/<tw-storydata[\s\S]*?<\/tw-storydata>/);
+  expect(match, 'output must contain <tw-storydata>').not.toBeNull();
+  return match![0];
+}
+
+/** Extract an attribute value from an HTML element string. */
+function attr(element: string, name: string): string | null {
+  const re = new RegExp(`${name}="([^"]*)"`, 'i');
+  const match = element.match(re);
+  return match ? match[1] : null;
+}
+
+/** Extract the opening <tw-storydata> tag. */
+function storyDataTag(html: string): string {
+  const chunk = extractStoryData(html);
+  const match = chunk.match(/<tw-storydata[^>]*>/);
+  expect(match).not.toBeNull();
+  return match![0];
+}
+
+/** Extract all <tw-passagedata> elements as strings. */
+function passageElements(html: string): string[] {
+  const chunk = extractStoryData(html);
+  return [...chunk.matchAll(/<tw-passagedata[^>]*>[\s\S]*?<\/tw-passagedata>/g)].map((m) => m[0]);
+}
+
+// =============================================================================
+// §1 — Root Structure: <tw-storydata>
+// =============================================================================
+describe('Twine 2 HTML Output Spec — Root Structure', () => {
+  it('output contains a single <tw-storydata> root element', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const matches = result.output.match(/<tw-storydata/g);
+    expect(matches).toHaveLength(1);
+    expect(result.output).toContain('</tw-storydata>');
+  });
+
+  it('<tw-storydata> wraps <style>, <script>, <tw-tag>, and <tw-passagedata> elements', async () => {
+    const source = minimalStory(
+      [
+        ':: Start',
+        'Hello',
+        '',
+        ':: CSS [stylesheet]',
+        'body { color: red; }',
+        '',
+        ':: JS [script]',
+        'window.x = 1;',
+      ].join('\n'),
+    );
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+
+    expect(chunk).toContain('<style');
+    expect(chunk).toContain('<script');
+    expect(chunk).toContain('<tw-passagedata');
+  });
+
+  it('<tw-storydata> has the hidden attribute', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const tag = storyDataTag(result.output);
+    expect(tag).toContain('hidden');
+  });
+});
+
+// =============================================================================
+// §2 — Story Data Attributes on <tw-storydata>
+// =============================================================================
+describe('Twine 2 HTML Output Spec — Story Data Attributes', () => {
+  it('name attribute: required, reflects StoryTitle', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const tag = storyDataTag(result.output);
+    expect(attr(tag, 'name')).toBe('Spec Test');
+  });
+
+  it('ifid attribute: required, matches StoryData IFID', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const tag = storyDataTag(result.output);
+    expect(attr(tag, 'ifid')).toBe('D674C58C-DEFA-4F70-B7A2-27742230C0FC');
+  });
+
+  it('format attribute: present when format is specified in StoryData', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube","format-version":"2.37.3"}',
+      '',
+      ':: StoryTitle',
+      'Format Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const tag = storyDataTag(result.output);
+    expect(attr(tag, 'format')).toBe('SugarCube');
+  });
+
+  it('format-version attribute: present when format-version is specified in StoryData', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube","format-version":"2.37.3"}',
+      '',
+      ':: StoryTitle',
+      'Format Version Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const tag = storyDataTag(result.output);
+    expect(attr(tag, 'format-version')).toBe('2.37.3');
+  });
+
+  it('startnode attribute: PID of the starting passage', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const tag = storyDataTag(result.output);
+    const startNode = attr(tag, 'startnode');
+    expect(startNode).not.toBeNull();
+    expect(startNode).not.toBe('');
+
+    // Verify the PID corresponds to a real passage
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'pid') === startNode);
+    expect(startPassage).toBeDefined();
+    expect(attr(startPassage!, 'name')).toBe('Start');
+  });
+
+  it('startnode matches the passage named in StoryData "start" field', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","start":"Begin"}',
+      '',
+      ':: StoryTitle',
+      'Start Test',
+      '',
+      ':: Start',
+      'Not this one',
+      '',
+      ':: Begin',
+      'This one!',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const tag = storyDataTag(result.output);
+    const startNode = attr(tag, 'startnode');
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'pid') === startNode);
+    expect(startPassage).toBeDefined();
+    expect(attr(startPassage!, 'name')).toBe('Begin');
+  });
+
+  it('zoom attribute: defaults to 1', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const tag = storyDataTag(result.output);
+    expect(attr(tag, 'zoom')).toBe('1');
+  });
+
+  it('zoom attribute: reflects custom zoom value', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","zoom":0.25}',
+      '',
+      ':: StoryTitle',
+      'Zoom Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const tag = storyDataTag(result.output);
+    expect(attr(tag, 'zoom')).toBe('0.25');
+  });
+
+  it('creator attribute: present on output', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const tag = storyDataTag(result.output);
+    expect(attr(tag, 'creator')).not.toBeNull();
+    expect(attr(tag, 'creator')).not.toBe('');
+  });
+
+  it('creator-version attribute: present on output', async () => {
+    const result = await compileToArchive(minimalStory(':: Start\nHello'));
+    const tag = storyDataTag(result.output);
+    expect(attr(tag, 'creator-version')).not.toBeNull();
+    expect(attr(tag, 'creator-version')).not.toBe('');
+  });
+
+  it('name attribute escapes special HTML characters', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}',
+      '',
+      ':: StoryTitle',
+      'A "Story" & <More>',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const tag = storyDataTag(result.output);
+    // Attribute values should have &, ", ' escaped; < and > are not escaped in attrEscape
+    expect(tag).toContain('name="A &quot;Story&quot; &amp;');
+    expect(tag).toContain('&amp;');
+  });
+});
+
+// =============================================================================
+// §3 — Passages: <tw-passagedata>
+// =============================================================================
+describe('Twine 2 HTML Output Spec — Passages (<tw-passagedata>)', () => {
+  it('each passage rendered as <tw-passagedata> element', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: Second', 'World'].join('\n'));
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    expect(passages.length).toBe(2);
+  });
+
+  it('pid attribute: required, unique integer', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: Second', 'World', '', ':: Third', 'Foo'].join('\n'));
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const pids = passages.map((p) => attr(p, 'pid'));
+    // All PIDs must be present
+    for (const pid of pids) {
+      expect(pid).not.toBeNull();
+      expect(pid).toMatch(/^\d+$/);
+    }
+    // All PIDs must be unique
+    expect(new Set(pids).size).toBe(pids.length);
+  });
+
+  it('name attribute: required, matches passage name', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    expect(passages.some((p) => attr(p, 'name') === 'Start')).toBe(true);
+  });
+
+  it('tags attribute: space-separated tag list', async () => {
+    const source = minimalStory(':: Start [tag1 tag2 tag3]\nHello');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    expect(attr(startPassage!, 'tags')).toBe('tag1 tag2 tag3');
+  });
+
+  it('tags attribute: empty string when no tags', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    expect(attr(startPassage!, 'tags')).toBe('');
+  });
+
+  it('position attribute: present (comma-separated X,Y)', async () => {
+    const source = minimalStory(':: Start {"position":"102,99"}\nHello');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    expect(attr(startPassage!, 'position')).toBe('102,99');
+  });
+
+  it('position attribute: auto-generated when not specified', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    const position = attr(startPassage!, 'position');
+    expect(position).not.toBeNull();
+    expect(position).toMatch(/^\d+,\d+$/);
+  });
+
+  it('size attribute: present (comma-separated width,height)', async () => {
+    const source = minimalStory(':: Start {"position":"102,99","size":"200,150"}\nHello');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    expect(attr(startPassage!, 'size')).toBe('200,150');
+  });
+
+  it('size attribute: defaults to 100,100 when not specified', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    expect(attr(startPassage!, 'size')).toBe('100,100');
+  });
+
+  it('passage content: stored as text node within <tw-passagedata>', async () => {
+    const source = minimalStory(':: Start\nHello, world!');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    expect(startPassage).toContain('Hello, world!');
+  });
+
+  it('passage content: & < > " \' are escaped to HTML entities', async () => {
+    const source = minimalStory(':: Start\nA & B < C > D "E" \'F\'');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    expect(startPassage).toContain('&amp;');
+    expect(startPassage).toContain('&lt;');
+    expect(startPassage).toContain('&gt;');
+    expect(startPassage).toContain('&quot;');
+    expect(startPassage).toContain('&#39;');
+    // Should NOT contain raw special characters in content
+    expect(startPassage).not.toMatch(/>.*[&](?!amp;|lt;|gt;|quot;|#39;).*</);
+  });
+
+  it('passage name with special characters is attribute-escaped', async () => {
+    const source = minimalStory(':: A "B" & C\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).toContain('name="A &quot;B&quot; &amp; C"');
+  });
+
+  it('special passages (StoryTitle, StoryData) are NOT rendered as <tw-passagedata>', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const names = passages.map((p) => attr(p, 'name'));
+    expect(names).not.toContain('StoryTitle');
+    expect(names).not.toContain('StoryData');
+  });
+
+  it('script-tagged passages are NOT rendered as <tw-passagedata>', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: MyScript [script]', 'window.x = 1;'].join('\n'));
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const names = passages.map((p) => attr(p, 'name'));
+    expect(names).not.toContain('MyScript');
+  });
+
+  it('stylesheet-tagged passages are NOT rendered as <tw-passagedata>', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: MyStyle [stylesheet]', 'body {}'].join('\n'));
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const names = passages.map((p) => attr(p, 'name'));
+    expect(names).not.toContain('MyStyle');
+  });
+});
+
+// =============================================================================
+// §4 — Story JavaScript: <script>
+// =============================================================================
+describe('Twine 2 HTML Output Spec — Story JavaScript', () => {
+  it('script element has type="text/twine-javascript"', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: JS [script]', 'window.x = 1;'].join('\n'));
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).toContain('type="text/twine-javascript"');
+  });
+
+  it('script element has id="twine-user-script"', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).toContain('id="twine-user-script"');
+  });
+
+  it('script element has role="script"', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).toContain('role="script"');
+  });
+
+  it('script-tagged passage content is placed inside <script> element', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: JS [script]', 'window.setup = {};'].join('\n'));
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const scriptMatch = chunk.match(/<script[^>]*>([\s\S]*?)<\/script>/);
+    expect(scriptMatch).not.toBeNull();
+    expect(scriptMatch![1]).toContain('window.setup = {};');
+  });
+
+  it('single <script> element even when no script passages exist (empty)', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const scriptMatches = [...chunk.matchAll(/<script[^>]*>/g)];
+    expect(scriptMatches).toHaveLength(1);
+  });
+
+  it('multiple script passages are merged into a single <script> element', async () => {
+    const source = minimalStory(
+      [
+        ':: Start',
+        'Hello',
+        '',
+        ':: Script1 [script]',
+        'window.a = 1;',
+        '',
+        ':: Script2 [script]',
+        'window.b = 2;',
+      ].join('\n'),
+    );
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const scriptMatches = [...chunk.matchAll(/<script[^>]*>/g)];
+    expect(scriptMatches).toHaveLength(1);
+    const scriptMatch = chunk.match(/<script[^>]*>([\s\S]*?)<\/script>/);
+    expect(scriptMatch![1]).toContain('window.a = 1;');
+    expect(scriptMatch![1]).toContain('window.b = 2;');
+  });
+});
+
+// =============================================================================
+// §5 — Story Stylesheet: <style>
+// =============================================================================
+describe('Twine 2 HTML Output Spec — Story Stylesheet', () => {
+  it('style element has type="text/twine-css"', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: CSS [stylesheet]', 'body { color: red; }'].join('\n'));
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).toContain('type="text/twine-css"');
+  });
+
+  it('style element has id="twine-user-stylesheet"', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).toContain('id="twine-user-stylesheet"');
+  });
+
+  it('style element has role="stylesheet"', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).toContain('role="stylesheet"');
+  });
+
+  it('stylesheet-tagged passage content is placed inside <style> element', async () => {
+    const source = minimalStory(
+      [':: Start', 'Hello', '', ':: CSS [stylesheet]', 'body { font-size: 1.5em; }'].join('\n'),
+    );
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const styleMatch = chunk.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+    expect(styleMatch).not.toBeNull();
+    expect(styleMatch![1]).toContain('body { font-size: 1.5em; }');
+  });
+
+  it('single <style> element even when no stylesheet passages exist (empty)', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const styleMatches = [...chunk.matchAll(/<style[^>]*>/g)];
+    expect(styleMatches).toHaveLength(1);
+  });
+
+  it('multiple stylesheet passages are merged into a single <style> element', async () => {
+    const source = minimalStory(
+      [
+        ':: Start',
+        'Hello',
+        '',
+        ':: Style1 [stylesheet]',
+        'body { color: red; }',
+        '',
+        ':: Style2 [stylesheet]',
+        'p { margin: 0; }',
+      ].join('\n'),
+    );
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const styleMatches = [...chunk.matchAll(/<style[^>]*>/g)];
+    expect(styleMatches).toHaveLength(1);
+    const styleMatch = chunk.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+    expect(styleMatch![1]).toContain('body { color: red; }');
+    expect(styleMatch![1]).toContain('p { margin: 0; }');
+  });
+});
+
+// =============================================================================
+// §6 — Passage Tag Colors: <tw-tag>
+// =============================================================================
+describe('Twine 2 HTML Output Spec — Passage Tag Colors (<tw-tag>)', () => {
+  it('tag colors from StoryData are rendered as <tw-tag> elements', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","tag-colors":{"foo":"red","bar":"green"}}',
+      '',
+      ':: StoryTitle',
+      'Tag Color Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).toContain('<tw-tag');
+  });
+
+  it('<tw-tag> has name attribute matching the tag name', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","tag-colors":{"foo":"red"}}',
+      '',
+      ':: StoryTitle',
+      'Tag Color Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const tagMatch = chunk.match(/<tw-tag[^>]*>/);
+    expect(tagMatch).not.toBeNull();
+    expect(attr(tagMatch![0], 'name')).toBe('foo');
+  });
+
+  it('<tw-tag> has color attribute matching the assigned color', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","tag-colors":{"foo":"red"}}',
+      '',
+      ':: StoryTitle',
+      'Tag Color Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const tagMatch = chunk.match(/<tw-tag[^>]*>/);
+    expect(tagMatch).not.toBeNull();
+    expect(attr(tagMatch![0], 'color')).toBe('red');
+  });
+
+  it('multiple tag colors produce multiple <tw-tag> elements', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","tag-colors":{"one":"gray","two":"purple","three":"orange"}}',
+      '',
+      ':: StoryTitle',
+      'Multi Tag Colors',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const tagMatches = [...chunk.matchAll(/<tw-tag[^>]*>/g)];
+    expect(tagMatches.length).toBe(3);
+  });
+
+  it('<tw-tag> elements are self-closing (empty content)', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","tag-colors":{"foo":"blue"}}',
+      '',
+      ':: StoryTitle',
+      'Tag Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).toMatch(/<tw-tag[^>]*><\/tw-tag>/);
+  });
+
+  it('no <tw-tag> elements when no tag colors are defined', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    expect(chunk).not.toContain('<tw-tag');
+  });
+});
+
+// =============================================================================
+// §7 — Full HTML Output (with Story Format)
+// =============================================================================
+describe('Twine 2 HTML Output Spec — Full HTML (with story format)', () => {
+  it('{{STORY_NAME}} placeholder is replaced with the story name', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToHTML(source);
+    // The test format template has {{STORY_NAME}} in <title>
+    expect(result.output).toContain('<title>Spec Test</title>');
+  });
+
+  it('{{STORY_DATA}} placeholder is replaced with the tw-storydata chunk', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToHTML(source);
+    expect(result.output).toContain('<tw-storydata');
+    expect(result.output).toContain('</tw-storydata>');
+  });
+
+  it('story name with HTML special characters is escaped in {{STORY_NAME}}', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}',
+      '',
+      ':: StoryTitle',
+      'Story & "Friends"',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToHTML(source);
+    expect(result.output).toContain('Story &amp; &quot;Friends&quot;');
+  });
+
+  it('output is a valid HTML document wrapping the story data', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToHTML(source);
+    expect(result.output).toContain('<html>');
+    expect(result.output).toContain('</html>');
+    expect(result.output).toContain('<head>');
+    expect(result.output).toContain('<body>');
+  });
+});
+
+// =============================================================================
+// §8 — Element Ordering within <tw-storydata>
+// =============================================================================
+describe('Twine 2 HTML Output Spec — Element Ordering', () => {
+  it('<style> appears before <tw-passagedata> elements', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const styleIdx = chunk.indexOf('<style');
+    const passageIdx = chunk.indexOf('<tw-passagedata');
+    expect(styleIdx).toBeGreaterThan(-1);
+    expect(passageIdx).toBeGreaterThan(-1);
+    expect(styleIdx).toBeLessThan(passageIdx);
+  });
+
+  it('<script> appears before <tw-passagedata> elements', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const scriptIdx = chunk.indexOf('<script');
+    const passageIdx = chunk.indexOf('<tw-passagedata');
+    expect(scriptIdx).toBeGreaterThan(-1);
+    expect(passageIdx).toBeGreaterThan(-1);
+    expect(scriptIdx).toBeLessThan(passageIdx);
+  });
+
+  it('<tw-tag> elements appear before <tw-passagedata> elements', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","tag-colors":{"foo":"red"}}',
+      '',
+      ':: StoryTitle',
+      'Order Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compileToArchive(source);
+    const chunk = extractStoryData(result.output);
+    const tagIdx = chunk.indexOf('<tw-tag');
+    const passageIdx = chunk.indexOf('<tw-passagedata');
+    expect(tagIdx).toBeGreaterThan(-1);
+    expect(passageIdx).toBeGreaterThan(-1);
+    expect(tagIdx).toBeLessThan(passageIdx);
+  });
+});
+
+// =============================================================================
+// §9 — IFID Generation
+// =============================================================================
+describe('Twine 2 HTML Output Spec — IFID', () => {
+  it('IFID is auto-generated when not provided', async () => {
+    const source = [':: StoryTitle', 'No IFID', '', ':: Start', 'Hello'].join('\n');
+    const result = await compileToArchive(source);
+    const tag = storyDataTag(result.output);
+    const ifid = attr(tag, 'ifid');
+    expect(ifid).not.toBeNull();
+    expect(ifid).not.toBe('');
+    // Must be uppercase hex with hyphens (UUID format)
+    expect(ifid).toMatch(/^[0-9A-F-]+$/);
+  });
+
+  it('IFID uses uppercase letters (Treaty of Babel compliance)', async () => {
+    const source = [':: StoryTitle', 'No IFID', '', ':: Start', 'Hello'].join('\n');
+    const result = await compileToArchive(source);
+    const tag = storyDataTag(result.output);
+    const ifid = attr(tag, 'ifid');
+    expect(ifid).toBe(ifid!.toUpperCase());
+  });
+
+  it('emits an error when IFID is missing', async () => {
+    const source = [':: StoryTitle', 'No IFID', '', ':: Start', 'Hello'].join('\n');
+    const result = await compileToArchive(source);
+    const ifidDiag = result.diagnostics.find((d) => d.message.toLowerCase().includes('ifid'));
+    expect(ifidDiag).toBeDefined();
+    expect(ifidDiag!.level).toBe('error');
+  });
+});
+
+// =============================================================================
+// §10 — Multiline Passage Content
+// =============================================================================
+describe('Twine 2 HTML Output Spec — Multiline Content', () => {
+  it('multiline passage content is preserved (HTML-escaped)', async () => {
+    const source = minimalStory(':: Start\nLine 1\nLine 2\nLine 3');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    expect(startPassage).toContain('Line 1\nLine 2\nLine 3');
+  });
+
+  it('empty passage produces empty <tw-passagedata> content', async () => {
+    const source = minimalStory(':: Start\n');
+    const result = await compileToArchive(source);
+    const passages = passageElements(result.output);
+    const startPassage = passages.find((p) => attr(p, 'name') === 'Start');
+    expect(startPassage).toBeDefined();
+    // Content between tags should be empty
+    const contentMatch = startPassage!.match(/>([^]*)<\/tw-passagedata>/);
+    expect(contentMatch).not.toBeNull();
+    expect(contentMatch![1].trim()).toBe('');
+  });
+});

--- a/specs/twine2-jsonoutput-spec.test.ts
+++ b/specs/twine2-jsonoutput-spec.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Twine 2 JSON Output Specification Compliance Tests (v1.0)
+ *
+ * Tests twee-ts against every requirement in the Twine 2 JSON Output Specification:
+ * https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-jsonoutput-doc.md
+ *
+ * Each describe block corresponds to a section of the spec.
+ */
+import { describe, it, expect } from 'vitest';
+import { compile } from '../src/compiler.js';
+
+/** Helper: compile inline twee source to JSON output. */
+async function compileToJSON(content: string) {
+  const result = await compile({
+    sources: [{ filename: 'spec-test.tw', content }],
+    outputMode: 'json',
+  });
+  return { ...result, json: JSON.parse(result.output) as Record<string, unknown> };
+}
+
+/** Helper: build a minimal valid twee source. */
+function minimalStory(passages: string): string {
+  return [
+    ':: StoryData',
+    '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}',
+    '',
+    ':: StoryTitle',
+    'Spec Test',
+    '',
+    passages,
+  ].join('\n');
+}
+
+/** Helper: build a full-featured story source. */
+function fullStory(passages: string): string {
+  return [
+    ':: StoryData',
+    '{',
+    '  "ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC",',
+    '  "format":"SugarCube",',
+    '  "format-version":"2.37.3",',
+    '  "start":"Begin",',
+    '  "tag-colors":{"scene":"green","character":"blue"},',
+    '  "zoom":0.25',
+    '}',
+    '',
+    ':: StoryTitle',
+    'Full Story',
+    '',
+    passages,
+  ].join('\n');
+}
+
+// =============================================================================
+// §1 — Story Data Encoding: Required Properties
+// =============================================================================
+describe('Twine 2 JSON Output Spec — Required Story Properties', () => {
+  it('name: required, matches StoryTitle', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(json.name).toBe('Spec Test');
+  });
+
+  it('passages: required, is an array', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(Array.isArray(json.passages)).toBe(true);
+    expect((json.passages as unknown[]).length).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// §2 — Story Data Encoding: Optional Properties
+// =============================================================================
+describe('Twine 2 JSON Output Spec — Optional Story Properties', () => {
+  it('ifid: present when defined in StoryData', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(json.ifid).toBe('D674C58C-DEFA-4F70-B7A2-27742230C0FC');
+  });
+
+  it('format: present when defined in StoryData', async () => {
+    const { json } = await compileToJSON(fullStory(':: Begin\nHello'));
+    expect(json.format).toBe('SugarCube');
+  });
+
+  it('format-version: present when defined in StoryData (hyphenated key)', async () => {
+    const { json } = await compileToJSON(fullStory(':: Begin\nHello'));
+    expect(json['format-version']).toBe('2.37.3');
+  });
+
+  it('start: present when defined in StoryData', async () => {
+    const { json } = await compileToJSON(fullStory(':: Begin\nHello'));
+    expect(json.start).toBe('Begin');
+  });
+
+  it('tag-colors: object of tag:color pairs (hyphenated key)', async () => {
+    const { json } = await compileToJSON(fullStory(':: Begin\nHello'));
+    const tagColors = json['tag-colors'] as Record<string, string>;
+    expect(tagColors).toEqual({ scene: 'green', character: 'blue' });
+  });
+
+  it('zoom: present when not default (1)', async () => {
+    const { json } = await compileToJSON(fullStory(':: Begin\nHello'));
+    expect(json.zoom).toBe(0.25);
+  });
+
+  it('zoom: omitted when default value (1)', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(json.zoom).toBeUndefined();
+  });
+
+  it('creator: present', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(typeof json.creator).toBe('string');
+    expect(json.creator).not.toBe('');
+  });
+
+  it('creator-version: present (hyphenated key)', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(typeof json['creator-version']).toBe('string');
+    expect(json['creator-version']).not.toBe('');
+  });
+
+  it('format: omitted when not defined', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(json.format).toBeUndefined();
+  });
+
+  it('format-version: omitted when not defined', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(json['format-version']).toBeUndefined();
+  });
+
+  it('start: omitted when not defined', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(json.start).toBeUndefined();
+  });
+
+  it('tag-colors: omitted when no tag colors defined', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(json['tag-colors']).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// §3 — Story Data Encoding: style and script
+// =============================================================================
+describe('Twine 2 JSON Output Spec — Style and Script', () => {
+  it('style: contains merged stylesheet passage content', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: CSS [stylesheet]', 'body { color: red; }'].join('\n'));
+    const { json } = await compileToJSON(source);
+    expect(json.style).toBe('body { color: red; }');
+  });
+
+  it('script: contains merged script passage content', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: JS [script]', 'window.setup = {};'].join('\n'));
+    const { json } = await compileToJSON(source);
+    expect(json.script).toBe('window.setup = {};');
+  });
+
+  it('style: empty string when no stylesheet passages', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(json.style).toBe('');
+  });
+
+  it('script: empty string when no script passages', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    expect(json.script).toBe('');
+  });
+
+  it('style: multiple stylesheet passages are merged', async () => {
+    const source = minimalStory(
+      [
+        ':: Start',
+        'Hello',
+        '',
+        ':: S1 [stylesheet]',
+        'body { color: red; }',
+        '',
+        ':: S2 [stylesheet]',
+        'p { margin: 0; }',
+      ].join('\n'),
+    );
+    const { json } = await compileToJSON(source);
+    const style = json.style as string;
+    expect(style).toContain('body { color: red; }');
+    expect(style).toContain('p { margin: 0; }');
+  });
+
+  it('script: multiple script passages are merged', async () => {
+    const source = minimalStory(
+      [':: Start', 'Hello', '', ':: J1 [script]', 'window.a = 1;', '', ':: J2 [script]', 'window.b = 2;'].join('\n'),
+    );
+    const { json } = await compileToJSON(source);
+    const script = json.script as string;
+    expect(script).toContain('window.a = 1;');
+    expect(script).toContain('window.b = 2;');
+  });
+});
+
+// =============================================================================
+// §4 — Passage Data Encoding
+// =============================================================================
+describe('Twine 2 JSON Output Spec — Passage Data', () => {
+  it('name: required, matches passage name', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    const passages = json.passages as { name: string }[];
+    expect(passages.some((p) => p.name === 'Start')).toBe(true);
+  });
+
+  it('tags: required, array of strings', async () => {
+    const source = minimalStory(':: Start [tag1 tag2]\nHello');
+    const { json } = await compileToJSON(source);
+    const passages = json.passages as { name: string; tags: string[] }[];
+    const start = passages.find((p) => p.name === 'Start');
+    expect(start).toBeDefined();
+    expect(Array.isArray(start!.tags)).toBe(true);
+    expect(start!.tags).toEqual(['tag1', 'tag2']);
+  });
+
+  it('tags: empty array when no tags', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    const passages = json.passages as { name: string; tags: string[] }[];
+    const start = passages.find((p) => p.name === 'Start');
+    expect(start).toBeDefined();
+    expect(start!.tags).toEqual([]);
+  });
+
+  it('text: required, contains passage content', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello, world!'));
+    const passages = json.passages as { name: string; text: string }[];
+    const start = passages.find((p) => p.name === 'Start');
+    expect(start).toBeDefined();
+    expect(start!.text).toBe('Hello, world!');
+  });
+
+  it('text: preserves multiline content', async () => {
+    const source = minimalStory(':: Start\nLine 1\nLine 2\nLine 3');
+    const { json } = await compileToJSON(source);
+    const passages = json.passages as { name: string; text: string }[];
+    const start = passages.find((p) => p.name === 'Start');
+    expect(start!.text).toBe('Line 1\nLine 2\nLine 3');
+  });
+
+  it('text: raw content (not HTML-escaped)', async () => {
+    const source = minimalStory(':: Start\nA & B < C > D');
+    const { json } = await compileToJSON(source);
+    const passages = json.passages as { name: string; text: string }[];
+    const start = passages.find((p) => p.name === 'Start');
+    expect(start!.text).toBe('A & B < C > D');
+  });
+
+  it('metadata: present with position and size when defined', async () => {
+    const source = minimalStory(':: Start {"position":"600,400","size":"100,200"}\nHello');
+    const { json } = await compileToJSON(source);
+    const passages = json.passages as { name: string; metadata?: { position?: string; size?: string } }[];
+    const start = passages.find((p) => p.name === 'Start');
+    expect(start).toBeDefined();
+    expect(start!.metadata).toBeDefined();
+    expect(start!.metadata!.position).toBe('600,400');
+    expect(start!.metadata!.size).toBe('100,200');
+  });
+
+  it('metadata: omitted when not defined', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    const passages = json.passages as { name: string; metadata?: unknown }[];
+    const start = passages.find((p) => p.name === 'Start');
+    expect(start).toBeDefined();
+    expect(start!.metadata).toBeUndefined();
+  });
+
+  it('metadata: only includes position when only position is set', async () => {
+    const source = minimalStory(':: Start {"position":"300,100"}\nHello');
+    const { json } = await compileToJSON(source);
+    const passages = json.passages as { name: string; metadata?: Record<string, string> }[];
+    const start = passages.find((p) => p.name === 'Start');
+    expect(start!.metadata).toBeDefined();
+    expect(start!.metadata!.position).toBe('300,100');
+    expect(start!.metadata!.size).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// §5 — Passage Exclusions
+// =============================================================================
+describe('Twine 2 JSON Output Spec — Passage Exclusions', () => {
+  it('StoryTitle is NOT included in passages array', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    const passages = json.passages as { name: string }[];
+    expect(passages.some((p) => p.name === 'StoryTitle')).toBe(false);
+  });
+
+  it('StoryData is NOT included in passages array', async () => {
+    const { json } = await compileToJSON(minimalStory(':: Start\nHello'));
+    const passages = json.passages as { name: string }[];
+    expect(passages.some((p) => p.name === 'StoryData')).toBe(false);
+  });
+
+  it('script-tagged passages are NOT included in passages array', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: JS [script]', 'window.x = 1;'].join('\n'));
+    const { json } = await compileToJSON(source);
+    const passages = json.passages as { name: string }[];
+    expect(passages.some((p) => p.name === 'JS')).toBe(false);
+  });
+
+  it('stylesheet-tagged passages are NOT included in passages array', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: CSS [stylesheet]', 'body {}'].join('\n'));
+    const { json } = await compileToJSON(source);
+    const passages = json.passages as { name: string }[];
+    expect(passages.some((p) => p.name === 'CSS')).toBe(false);
+  });
+
+  it('Twine.private-tagged passages are NOT included in passages array', async () => {
+    const source = minimalStory([':: Start', 'Hello', '', ':: Hidden [Twine.private]', 'Secret'].join('\n'));
+    const { json } = await compileToJSON(source);
+    const passages = json.passages as { name: string }[];
+    expect(passages.some((p) => p.name === 'Hidden')).toBe(false);
+  });
+
+  it('only story passages appear in passages array', async () => {
+    const source = minimalStory(
+      [
+        ':: Start',
+        'Hello',
+        '',
+        ':: Second',
+        'World',
+        '',
+        ':: JS [script]',
+        'code',
+        '',
+        ':: CSS [stylesheet]',
+        'styles',
+      ].join('\n'),
+    );
+    const { json } = await compileToJSON(source);
+    const passages = json.passages as { name: string }[];
+    const names = passages.map((p) => p.name);
+    expect(names).toEqual(['Start', 'Second']);
+  });
+});
+
+// =============================================================================
+// §6 — Output is Valid JSON
+// =============================================================================
+describe('Twine 2 JSON Output Spec — Valid JSON', () => {
+  it('output parses as valid JSON', async () => {
+    const result = await compile({
+      sources: [{ filename: 'test.tw', content: minimalStory(':: Start\nHello') }],
+      outputMode: 'json',
+    });
+    expect(() => JSON.parse(result.output)).not.toThrow();
+  });
+
+  it('output matches spec example structure', async () => {
+    const { json } = await compileToJSON(
+      fullStory(':: Begin [tag1 tag2] {"position":"600,400","size":"100,200"}\nContent here'),
+    );
+    // Required top-level keys
+    expect(typeof json.name).toBe('string');
+    expect(Array.isArray(json.passages)).toBe(true);
+    // Optional top-level keys (present because fullStory defines them)
+    expect(typeof json.ifid).toBe('string');
+    expect(typeof json.format).toBe('string');
+    expect(typeof json['format-version']).toBe('string');
+    expect(typeof json.start).toBe('string');
+    expect(typeof json['tag-colors']).toBe('object');
+    expect(typeof json.zoom).toBe('number');
+    expect(typeof json.creator).toBe('string');
+    expect(typeof json['creator-version']).toBe('string');
+    expect(typeof json.style).toBe('string');
+    expect(typeof json.script).toBe('string');
+    // Passage structure
+    const passage = (json.passages as Record<string, unknown>[])[0];
+    expect(typeof passage.name).toBe('string');
+    expect(Array.isArray(passage.tags)).toBe(true);
+    expect(typeof passage.text).toBe('string');
+    expect(typeof passage.metadata).toBe('object');
+  });
+
+  it('no legacy twine2 nested object in output', async () => {
+    const { json } = await compileToJSON(fullStory(':: Begin\nHello'));
+    expect(json.twine2).toBeUndefined();
+  });
+});

--- a/specs/twine2-storyformats-spec.test.ts
+++ b/specs/twine2-storyformats-spec.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Twine 2 Story Formats Specification Compliance Tests (v1.0.0)
+ *
+ * Tests twee-ts against every requirement in the Twine 2 Story Formats Specification:
+ * https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-storyformats-spec.md
+ *
+ * Each describe block corresponds to a section of the spec.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { join } from 'node:path';
+import { readFileSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { compile } from '../src/compiler.js';
+import { discoverFormats } from '../src/formats.js';
+
+const FIXTURES_DIR = join(__dirname, '..', 'test', 'fixtures');
+const FORMAT_DIR = join(FIXTURES_DIR, 'storyformats');
+const TEMP_DIR = join(__dirname, '..', 'test', '.tmp-storyformat-spec');
+
+/** Helper: build a minimal valid twee source. */
+function minimalStory(passages: string): string {
+  return [
+    ':: StoryData',
+    '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}',
+    '',
+    ':: StoryTitle',
+    'Spec Test',
+    '',
+    passages,
+  ].join('\n');
+}
+
+/** Helper: write a temporary story format file. */
+function writeTempFormat(dirName: string, content: string): string {
+  const dir = join(TEMP_DIR, dirName);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, 'format.js');
+  writeFileSync(path, content, 'utf-8');
+  return TEMP_DIR;
+}
+
+/** Clean up temp directory after tests. */
+function cleanupTemp(): void {
+  try {
+    rmSync(TEMP_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+}
+
+// =============================================================================
+// §1 — Story Format Structure: Wrapper
+// =============================================================================
+describe('Twine 2 Story Formats Spec — Wrapper', () => {
+  it('format.js calls window.storyFormat() with an object argument', () => {
+    const content = readFileSync(join(FORMAT_DIR, 'test-format-1', 'format.js'), 'utf-8');
+    expect(content).toMatch(/window\.storyFormat\s*\(/);
+  });
+
+  it('discovers formats from directory structure', () => {
+    const formats = discoverFormats([FORMAT_DIR]);
+    expect(formats.size).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// §2 — Story Format Keys
+// =============================================================================
+describe('Twine 2 Story Formats Spec — Keys', () => {
+  afterAll(() => cleanupTemp());
+
+  it('name key: extracted from format.js', () => {
+    const formats = discoverFormats([FORMAT_DIR]);
+    const format = formats.get('test-format-1');
+    expect(format).toBeDefined();
+    expect(format!.name).toBe('Test Format');
+  });
+
+  it('version key: required, extracted from format.js', () => {
+    const formats = discoverFormats([FORMAT_DIR]);
+    const format = formats.get('test-format-1');
+    expect(format).toBeDefined();
+    expect(format!.version).toBeTruthy();
+    // Must be semantic version style (x.y.z)
+    expect(format!.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('source key: required, contains HTML template', () => {
+    const content = readFileSync(join(FORMAT_DIR, 'test-format-1', 'format.js'), 'utf-8');
+    // Parse the JSON object from the storyFormat call
+    const match = content.match(/window\.storyFormat\s*\(([\s\S]*)\)\s*;?\s*$/);
+    expect(match).not.toBeNull();
+    const obj = JSON.parse(match![1]);
+    expect(obj.source).toBeDefined();
+    expect(typeof obj.source).toBe('string');
+    expect(obj.source).toContain('<html>');
+  });
+
+  it('source key: contains {{STORY_NAME}} placeholder', () => {
+    const content = readFileSync(join(FORMAT_DIR, 'test-format-1', 'format.js'), 'utf-8');
+    const match = content.match(/window\.storyFormat\s*\(([\s\S]*)\)\s*;?\s*$/);
+    const obj = JSON.parse(match![1]);
+    expect(obj.source).toContain('{{STORY_NAME}}');
+  });
+
+  it('source key: contains {{STORY_DATA}} placeholder', () => {
+    const content = readFileSync(join(FORMAT_DIR, 'test-format-1', 'format.js'), 'utf-8');
+    const match = content.match(/window\.storyFormat\s*\(([\s\S]*)\)\s*;?\s*$/);
+    const obj = JSON.parse(match![1]);
+    expect(obj.source).toContain('{{STORY_DATA}}');
+  });
+
+  it('proofing key: defaults to false when not specified', () => {
+    const formats = discoverFormats([FORMAT_DIR]);
+    const format = formats.get('test-format-1');
+    expect(format).toBeDefined();
+    expect(format!.proofing).toBe(false);
+  });
+
+  it('format with proofing=true is recognized as proofing format', () => {
+    const formatDir = writeTempFormat(
+      'proofing-format',
+      'window.storyFormat({"name":"Proof","version":"1.0.0","proofing":true,"source":"<html>{{STORY_DATA}}</html>"});',
+    );
+    const formats = discoverFormats([formatDir]);
+    const proofFormat = [...formats.values()].find((f) => f.name === 'Proof');
+    expect(proofFormat).toBeDefined();
+    expect(proofFormat!.proofing).toBe(true);
+  });
+});
+
+// =============================================================================
+// §3 — Placeholders: {{STORY_NAME}} and {{STORY_DATA}}
+// =============================================================================
+describe('Twine 2 Story Formats Spec — Placeholder Replacement', () => {
+  it('{{STORY_NAME}} is replaced with the HTML-escaped story name', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compile({
+      sources: [{ filename: 'test.tw', content: source }],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+    });
+    expect(result.output).toContain('Spec Test');
+    expect(result.output).not.toContain('{{STORY_NAME}}');
+  });
+
+  it('{{STORY_DATA}} is replaced with <tw-storydata> chunk', async () => {
+    const source = minimalStory(':: Start\nHello');
+    const result = await compile({
+      sources: [{ filename: 'test.tw', content: source }],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+    });
+    expect(result.output).toContain('<tw-storydata');
+    expect(result.output).not.toContain('{{STORY_DATA}}');
+  });
+
+  afterAll(() => cleanupTemp());
+
+  it('placeholders not present in source are left as-is (no crash)', async () => {
+    const formatDir = writeTempFormat(
+      'no-placeholder-format',
+      'window.storyFormat({"name":"Bare","version":"1.0.0","source":"<html><body>No placeholders</body></html>"});',
+    );
+    const source = minimalStory(':: Start\nHello');
+    const result = await compile({
+      sources: [{ filename: 'test.tw', content: source }],
+      formatId: 'no-placeholder-format',
+      formatPaths: [formatDir],
+      useTweegoPath: false,
+    });
+    // Output should be the format source unchanged (no crash)
+    expect(result.output).toContain('No placeholders');
+  });
+});
+
+// =============================================================================
+// §4 — Format Discovery
+// =============================================================================
+describe('Twine 2 Story Formats Spec — Discovery', () => {
+  afterAll(() => cleanupTemp());
+
+  it('discovers format from format.js in a named directory', () => {
+    const formats = discoverFormats([FORMAT_DIR]);
+    expect(formats.has('test-format-1')).toBe(true);
+  });
+
+  it('format id is derived from containing directory name', () => {
+    const formats = discoverFormats([FORMAT_DIR]);
+    const format = formats.get('test-format-1');
+    expect(format).toBeDefined();
+    expect(format!.id).toBe('test-format-1');
+  });
+
+  it('format filename is format.js', () => {
+    const formats = discoverFormats([FORMAT_DIR]);
+    const format = formats.get('test-format-1');
+    expect(format).toBeDefined();
+    expect(format!.filename).toContain('format.js');
+  });
+
+  it('multiple format directories are all discovered', () => {
+    const formatDir1 = writeTempFormat(
+      'format-a',
+      'window.storyFormat({"name":"FormatA","version":"1.0.0","source":"<html>{{STORY_DATA}}</html>"});',
+    );
+    writeTempFormat(
+      'format-b',
+      'window.storyFormat({"name":"FormatB","version":"2.0.0","source":"<html>{{STORY_DATA}}</html>"});',
+    );
+    const formats = discoverFormats([formatDir1]);
+    const names = [...formats.values()].map((f) => f.name);
+    expect(names).toContain('FormatA');
+    expect(names).toContain('FormatB');
+  });
+});
+
+// =============================================================================
+// §5 — Twine 2 Format Detection
+// =============================================================================
+describe('Twine 2 Story Formats Spec — Twine 2 Detection', () => {
+  it('format is identified as Twine 2 format', () => {
+    const formats = discoverFormats([FORMAT_DIR]);
+    const format = formats.get('test-format-1');
+    expect(format).toBeDefined();
+    expect(format!.isTwine2).toBe(true);
+  });
+});
+
+// =============================================================================
+// §6 — Format Selection from StoryData
+// =============================================================================
+describe('Twine 2 Story Formats Spec — Format Selection via StoryData', () => {
+  afterAll(() => cleanupTemp());
+
+  it('format specified in StoryData is used for compilation', async () => {
+    const formatDir = writeTempFormat(
+      'sugarcube-2',
+      'window.storyFormat({"name":"SugarCube","version":"2.37.3","source":"<html><head>SC</head><body>{{STORY_DATA}}</body></html>"});',
+    );
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube","format-version":"2.37.3"}',
+      '',
+      ':: StoryTitle',
+      'Format Selection',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compile({
+      sources: [{ filename: 'test.tw', content: source }],
+      formatPaths: [formatDir],
+      useTweegoPath: false,
+    });
+    expect(result.output).toContain('SC');
+    expect(result.format?.name).toBe('SugarCube');
+  });
+
+  it('explicit formatId option overrides StoryData format', async () => {
+    const source = [
+      ':: StoryData',
+      '{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube","format-version":"2.37.3"}',
+      '',
+      ':: StoryTitle',
+      'Override Test',
+      '',
+      ':: Start',
+      'Hello',
+    ].join('\n');
+    const result = await compile({
+      sources: [{ filename: 'test.tw', content: source }],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+    });
+    expect(result.format?.name).toBe('Test Format');
+  });
+});
+
+// =============================================================================
+// §7 — Version Requirements
+// =============================================================================
+describe('Twine 2 Story Formats Spec — Version', () => {
+  afterAll(() => cleanupTemp());
+
+  it('version must be semantic version format (x.y.z)', () => {
+    const formats = discoverFormats([FORMAT_DIR]);
+    for (const [, format] of formats) {
+      expect(format.version).toMatch(/^\d+\.\d+\.\d+/);
+    }
+  });
+
+  it('format with non-semver version still loads (graceful handling)', () => {
+    const formatDir = writeTempFormat(
+      'odd-version-format',
+      'window.storyFormat({"name":"OddVer","version":"1.0","source":"<html>{{STORY_DATA}}</html>"});',
+    );
+    const formats = discoverFormats([formatDir]);
+    const format = [...formats.values()].find((f) => f.name === 'OddVer');
+    expect(format).toBeDefined();
+  });
+});

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -20,12 +20,15 @@ import { createStory, storyHas, getStoryStats } from './story.js';
 import { getFilenames, watchFilesystem } from './filesystem.js';
 import { discoverFormats, getFormatSearchDirs, getFormatIdByNameAndVersion } from './formats.js';
 import { loadSources, loadInlineSources } from './loader.js';
-import { applyTagAliases } from './passage.js';
+import { applyTagAliases, hasTag } from './passage.js';
 import { toTwine2HTML, toTwine2Archive } from './output-twine2.js';
 import { toTwine1HTML, toTwine1Archive } from './output-twine1.js';
 import { toTwee } from './output-twee.js';
 import { modifyHead } from './modules.js';
 import { resolveRemoteFormat, clearIndexCache } from './remote-formats.js';
+import { VERSION } from './version.js';
+
+const CREATOR_NAME = 'Twee-ts';
 
 const DEFAULT_FORMAT_ID = 'sugarcube-2';
 const DEFAULT_START_NAME = 'Start';
@@ -236,27 +239,55 @@ async function buildOutput(options: CompileOptions): Promise<CompileResult> {
   return { output, story, format, diagnostics, stats };
 }
 
+/**
+ * Serialize a Story to JSON per the Twine 2 JSON Output Specification (v1.0):
+ * https://github.com/iftechfoundation/twine-specs/blob/master/twine-2-jsonoutput-doc.md
+ */
 function storyToJSON(story: Story): string {
-  return JSON.stringify(
-    {
-      name: story.name,
-      ifid: story.ifid,
-      passages: story.passages.map((p) => ({
+  // Gather script and stylesheet content, excluding them from passages.
+  const scripts: string[] = [];
+  const stylesheets: string[] = [];
+  const storyPassages: { name: string; tags: string[]; text: string; metadata?: Record<string, string> }[] = [];
+
+  for (const p of story.passages) {
+    if (p.name === 'StoryTitle' || p.name === 'StoryData') continue;
+    if (hasTag(p, 'Twine.private')) continue;
+
+    if (hasTag(p, 'script')) {
+      scripts.push(p.text);
+    } else if (hasTag(p, 'stylesheet')) {
+      stylesheets.push(p.text);
+    } else {
+      const entry: { name: string; tags: string[]; text: string; metadata?: Record<string, string> } = {
         name: p.name,
         tags: p.tags,
         text: p.text,
-        metadata: p.metadata ?? null,
-      })),
-      twine2: {
-        format: story.twine2.format,
-        formatVersion: story.twine2.formatVersion,
-        start: story.twine2.start,
-        tagColors: Object.fromEntries(story.twine2.tagColors),
-        options: Object.fromEntries(story.twine2.options),
-        zoom: story.twine2.zoom,
-      },
-    },
-    null,
-    2,
-  );
+      };
+      if (p.metadata && (p.metadata.position || p.metadata.size)) {
+        const meta: Record<string, string> = {};
+        if (p.metadata.position) meta.position = p.metadata.position;
+        if (p.metadata.size) meta.size = p.metadata.size;
+        entry.metadata = meta;
+      }
+      storyPassages.push(entry);
+    }
+  }
+
+  const obj: Record<string, unknown> = {
+    name: story.name,
+  };
+
+  if (story.ifid) obj.ifid = story.ifid;
+  if (story.twine2.format) obj.format = story.twine2.format;
+  if (story.twine2.formatVersion) obj['format-version'] = story.twine2.formatVersion;
+  if (story.twine2.start) obj.start = story.twine2.start;
+  if (story.twine2.tagColors.size > 0) obj['tag-colors'] = Object.fromEntries(story.twine2.tagColors);
+  if (story.twine2.zoom !== 1) obj.zoom = story.twine2.zoom;
+  obj.creator = CREATOR_NAME;
+  obj['creator-version'] = VERSION;
+  obj.style = stylesheets.join('\n');
+  obj.script = scripts.join('\n');
+  obj.passages = storyPassages;
+
+  return JSON.stringify(obj, null, 2);
 }

--- a/src/output-twine2.ts
+++ b/src/output-twine2.ts
@@ -111,8 +111,7 @@ function getTwine2DataChunk(story: Story, startName: string, diagnostics: Diagno
   const options = opts.join(' ');
 
   // Wrap in tw-storydata
-  const zoom =
-    story.twine2.zoom === Math.floor(story.twine2.zoom) ? story.twine2.zoom.toString() : story.twine2.zoom.toFixed(1);
+  const zoom = String(story.twine2.zoom);
 
   const wrapper =
     `<!-- UUID://${htmlCommentSanitize(story.ifid)}// -->` +
@@ -130,16 +129,17 @@ function ensureIFID(story: Story, diagnostics: Diagnostic[]): void {
   if (story.ifid !== '') return;
 
   if (story.legacyIFID !== '') {
+    story.ifid = story.legacyIFID;
     diagnostics.push({
       level: 'warning',
       message: 'Story IFID not found; reusing "ifid" entry from the "StorySettings" special passage.',
     });
-    story.ifid = story.legacyIFID;
   } else {
-    story.ifid = generateIFID();
+    const ifid = generateIFID();
+    story.ifid = ifid;
     diagnostics.push({
-      level: 'warning',
-      message: `Story IFID not found; generated ${story.ifid} for your project. Add it to a StoryData passage.`,
+      level: 'error',
+      message: `Story IFID not found. Add a StoryData passage with: {"ifid":"${ifid}"}`,
     });
   }
 }

--- a/test/compile.test.ts
+++ b/test/compile.test.ts
@@ -87,17 +87,17 @@ describe('compile', () => {
     expect(result.output).not.toContain('<html>');
   });
 
-  it('preserves story metadata', async () => {
+  it('preserves story metadata in JSON output (spec-compliant keys)', async () => {
     const result = await compile({
       sources: [join(FIXTURES_DIR, 'storydata.tw')],
       outputMode: 'json',
     });
 
     const json = JSON.parse(result.output);
-    expect(json.twine2.format).toBe('SugarCube');
-    expect(json.twine2.formatVersion).toBe('2.37.3');
-    expect(json.twine2.start).toBe('Begin');
-    expect(json.twine2.tagColors).toEqual({ location: 'green', character: 'blue' });
+    expect(json.format).toBe('SugarCube');
+    expect(json['format-version']).toBe('2.37.3');
+    expect(json.start).toBe('Begin');
+    expect(json['tag-colors']).toEqual({ location: 'green', character: 'blue' });
   });
 
   it('reports diagnostics rather than throwing', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['test/**/*.test.ts'],
+    include: ['test/**/*.test.ts', 'specs/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- Add 298 spec compliance tests across 6 test suites (`specs/`) validating output against the official [iftechfoundation/twine-specs](https://github.com/iftechfoundation/twine-specs)
- Refactor JSON output to follow the Twine 2 JSON Output Specification (top-level `format`, `format-version`, `start`, `tag-colors`, `zoom`, `creator`, `creator-version`, `style`, `script` keys)
- Change missing IFID diagnostic from warning to error with actionable message
- Add Twine 1 HTML output spec tests (34 tests covering root structure, passage attributes, tiddler escaping, special passages, Twine.private filtering)

## Checklist
- [x] Tests pass (`pnpm test` — 428 tests)
- [x] Type check passes (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm run build`)
- [x] Formatting clean (`pnpm run format:check`)
- [x] CHANGELOG.md updated with new version

## Release
Merging this PR will trigger `release-npm-action` to publish v1.3.0 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)