### PR TITLE
release: v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-03-06
+
+### Added
+
+- Source location tracking for passages — the parser now records source file and line number on every parsed passage (`Passage.source`)
+- `--source-info` CLI flag and `sourceInfo` compile option to emit `data-source-file` and `data-source-line` attributes on `<tw-passagedata>` elements in HTML output
+- `SourceLocation` type exported from the public API
+
 ## [1.4.0] - 2026-03-05
 
 ### Added

--- a/bin/twee-ts.ts
+++ b/bin/twee-ts.ts
@@ -41,6 +41,7 @@ const { values, positionals } = parseArgs({
     'format-url': { type: 'string', multiple: true },
     'no-remote': { type: 'boolean' },
     'tag-alias': { type: 'string', multiple: true },
+    'source-info': { type: 'boolean' },
     config: { type: 'string', short: 'c' },
     'no-config': { type: 'boolean' },
   },
@@ -123,6 +124,7 @@ async function main(): Promise<void> {
     formatUrls: values['format-url'] ?? config?.formatUrls,
     noRemote: values['no-remote'] ?? config?.noRemote ?? false,
     tagAliases,
+    sourceInfo: values['source-info'] ?? config?.sourceInfo ?? false,
   };
 
   const outFile = values.output ?? config?.output ?? '-';
@@ -262,6 +264,7 @@ Options:
   --format-index <url>      SFA-compatible format index URL (repeatable)
   --format-url <url>        Direct format.js URL (repeatable)
   --tag-alias <alias=target> Map a tag to a special tag (repeatable)
+  --source-info             Emit source file/line as data- attributes on passages
   --no-remote               Disable remote format fetching
   -c, --config <file>       Config file path (default: ${CONFIG_FILENAME})
   --no-config               Skip config file loading

--- a/docs/api.md
+++ b/docs/api.md
@@ -80,6 +80,7 @@ interface CompileOptions {
   formatUrls?: string[];
   noRemote?: boolean; // default: false
   tagAliases?: Record<string, string>;
+  sourceInfo?: boolean; // default: false
 }
 ```
 
@@ -270,6 +271,7 @@ import type {
   ItemType,
   SFAIndex,
   SFAIndexEntry,
+  SourceLocation,
   TweeTsConfig,
 } from '@rohal12/twee-ts';
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,6 +44,7 @@ See [Output Modes](./output-modes) for details on each mode.
 | `--no-trim`                  | Don't trim leading/trailing whitespace from passages.                            |
 | `-t, --test`                 | Enable test/debug mode (sets `debug` option in story data).                      |
 | `--tag-alias <alias=target>` | Map a custom tag to a special tag. Repeatable. See [Tag Aliases](./tag-aliases). |
+| `--source-info`              | Emit source file and line as `data-` attributes on passage elements.             |
 
 ### Story Formats
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,7 +34,8 @@ Every key with its default value:
   "twee2Compat": false,
   "testMode": false,
   "noRemote": false,
-  "tagAliases": {}
+  "tagAliases": {},
+  "sourceInfo": false
 }
 ```
 
@@ -61,12 +62,13 @@ Every key with its default value:
 
 ### Compilation
 
-| Key            | Type      | Default   | Description                                                     |
-| -------------- | --------- | --------- | --------------------------------------------------------------- |
-| `startPassage` | `string`  | `"Start"` | Name of the starting passage.                                   |
-| `trim`         | `boolean` | `true`    | Trim leading and trailing whitespace from passage content.      |
-| `twee2Compat`  | `boolean` | `false`   | Enable Twee2 syntax compatibility mode.                         |
-| `testMode`     | `boolean` | `false`   | Enable test/debug mode (sets the `debug` option in story data). |
+| Key            | Type      | Default   | Description                                                       |
+| -------------- | --------- | --------- | ----------------------------------------------------------------- |
+| `startPassage` | `string`  | `"Start"` | Name of the starting passage.                                     |
+| `trim`         | `boolean` | `true`    | Trim leading and trailing whitespace from passage content.        |
+| `twee2Compat`  | `boolean` | `false`   | Enable Twee2 syntax compatibility mode.                           |
+| `testMode`     | `boolean` | `false`   | Enable test/debug mode (sets the `debug` option in story data).   |
+| `sourceInfo`   | `boolean` | `false`   | Embed source file/line as `data-` attributes on passage elements. |
 
 ### Head Injection
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -92,6 +92,7 @@ async function buildOutput(options: CompileOptions): Promise<CompileResult> {
   const twee2Compat = options.twee2Compat ?? false;
   const testMode = options.testMode ?? false;
   const noRemote = options.noRemote ?? false;
+  const sourceInfo = options.sourceInfo ?? false;
 
   // Clear per-compile index cache
   clearIndexCache();
@@ -182,7 +183,7 @@ async function buildOutput(options: CompileOptions): Promise<CompileResult> {
       break;
 
     case 'twine2-archive':
-      output = toTwine2Archive(story, startName, diagnostics);
+      output = toTwine2Archive(story, startName, diagnostics, { sourceInfo });
       break;
 
     case 'twine1-archive':
@@ -207,7 +208,7 @@ async function buildOutput(options: CompileOptions): Promise<CompileResult> {
       }
 
       if (format.isTwine2) {
-        output = toTwine2HTML(story, format, startName, diagnostics);
+        output = toTwine2HTML(story, format, startName, diagnostics, { sourceInfo });
       } else {
         if (story.name === '' && !storyHas(story, 'StoryTitle')) {
           diagnostics.push({

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,7 +81,7 @@ export function validateConfig(data: unknown): string[] {
   }
 
   // Boolean fields
-  for (const key of ['useTweegoPath', 'trim', 'twee2Compat', 'testMode', 'noRemote'] as const) {
+  for (const key of ['useTweegoPath', 'trim', 'twee2Compat', 'testMode', 'noRemote', 'sourceInfo'] as const) {
     if (key in obj && typeof obj[key] !== 'boolean') {
       errors.push(`"${key}" must be a boolean.`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export type {
   ItemType,
   SFAIndex,
   SFAIndexEntry,
+  SourceLocation,
   TweeTsConfig,
 } from './types.js';
 export type { StoryMap, BrokenLink } from './inspect.js';

--- a/src/output-twine2.ts
+++ b/src/output-twine2.ts
@@ -11,8 +11,13 @@ import { VERSION } from './version.js';
 
 const CREATOR_NAME = 'Twee-ts';
 
-export function toTwine2Archive(story: Story, startName: string, diagnostics: Diagnostic[]): string {
-  return getTwine2DataChunk(story, startName, diagnostics) + '\n';
+export function toTwine2Archive(
+  story: Story,
+  startName: string,
+  diagnostics: Diagnostic[],
+  options?: { readonly sourceInfo?: boolean },
+): string {
+  return getTwine2DataChunk(story, startName, diagnostics, options) + '\n';
 }
 
 export function toTwine2HTML(
@@ -20,6 +25,7 @@ export function toTwine2HTML(
   format: StoryFormatInfo,
   startName: string,
   diagnostics: Diagnostic[],
+  options?: { readonly sourceInfo?: boolean },
 ): string {
   let template = readFormatSource(format);
 
@@ -27,13 +33,18 @@ export function toTwine2HTML(
     template = template.replaceAll('{{STORY_NAME}}', htmlEscape(story.name));
   }
   if (template.includes('{{STORY_DATA}}')) {
-    template = template.replace('{{STORY_DATA}}', getTwine2DataChunk(story, startName, diagnostics));
+    template = template.replace('{{STORY_DATA}}', getTwine2DataChunk(story, startName, diagnostics, options));
   }
 
   return template;
 }
 
-function getTwine2DataChunk(story: Story, startName: string, diagnostics: Diagnostic[]): string {
+function getTwine2DataChunk(
+  story: Story,
+  startName: string,
+  diagnostics: Diagnostic[],
+  options?: { readonly sourceInfo?: boolean },
+): string {
   // Check IFID status and generate if missing.
   ensureIFID(story, diagnostics);
 
@@ -100,7 +111,7 @@ function getTwine2DataChunk(story: Story, startName: string, diagnostics: Diagno
       continue;
     }
 
-    parts.push(passageToPassagedata(p, pid));
+    parts.push(passageToPassagedata(p, pid, options));
     if (startName === p.name) {
       startID = String(pid);
     }
@@ -112,7 +123,7 @@ function getTwine2DataChunk(story: Story, startName: string, diagnostics: Diagno
   for (const [opt, val] of story.twine2.options) {
     if (val) opts.push(opt);
   }
-  const options = opts.join(' ');
+  const optionsStr = opts.join(' ');
 
   // Wrap in tw-storydata
   const zoom = String(story.twine2.zoom);
@@ -124,7 +135,7 @@ function getTwine2DataChunk(story: Story, startName: string, diagnostics: Diagno
     `ifid="${attrEscape(story.ifid)}" zoom="${attrEscape(zoom)}" ` +
     `format="${attrEscape(story.twine2.format)}" ` +
     `format-version="${attrEscape(story.twine2.formatVersion)}" ` +
-    `options="${attrEscape(options)}" tags="${attrEscape(story.twine2.tags)}" hidden>`;
+    `options="${attrEscape(optionsStr)}" tags="${attrEscape(story.twine2.tags)}" hidden>`;
 
   return wrapper + parts.join('') + '</tw-storydata>';
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -61,7 +61,7 @@ export function parseTwee(source: string, options: ParseOptions = {}): ParseResu
         if (pCount > 1 && current) {
           passages.push(current);
         }
-        current = { name: '', tags: [], text: '' };
+        current = { name: '', tags: [], text: '', source: { file: filename, line: item.line } };
         break;
 
       case ItemType.Name: {

--- a/src/passage.ts
+++ b/src/passage.ts
@@ -118,7 +118,7 @@ export function passageToTwee(p: Passage, outMode: OutputMode): string {
 }
 
 /** Generate `<tw-passagedata>` HTML for Twine 2. */
-export function passageToPassagedata(p: Passage, pid: number): string {
+export function passageToPassagedata(p: Passage, pid: number, options?: { readonly sourceInfo?: boolean }): string {
   let position: string;
   let size: string;
 
@@ -138,7 +138,11 @@ export function passageToPassagedata(p: Passage, pid: number): string {
     size = '100,100';
   }
 
-  return `<tw-passagedata pid="${pid}" name=${quote(fullAttrEscape(p.name))} tags=${quote(attrEscape(p.tags.join(' ')))} position=${quote(attrEscape(position))} size=${quote(attrEscape(size))}>${htmlEscape(p.text)}</tw-passagedata>`;
+  let attrs = `<tw-passagedata pid="${pid}" name=${quote(fullAttrEscape(p.name))} tags=${quote(attrEscape(p.tags.join(' ')))} position=${quote(attrEscape(position))} size=${quote(attrEscape(size))}`;
+  if (options?.sourceInfo && p.source) {
+    attrs += ` data-source-file=${quote(attrEscape(p.source.file))} data-source-line="${p.source.line}"`;
+  }
+  return `${attrs}>${htmlEscape(p.text)}</tw-passagedata>`;
 }
 
 /** Generate `<div tiddler>` HTML for Twine 1. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,8 @@ export interface CompileOptions {
   noRemote?: boolean;
   /** Map alias tags to canonical special tags (e.g. { library: 'script' }). */
   tagAliases?: Record<string, string>;
+  /** Emit source file and line as data- attributes on passage elements. Default: false. */
+  sourceInfo?: boolean;
 }
 
 export interface CompileToFileOptions extends CompileOptions {
@@ -89,6 +91,11 @@ export interface CompileStats {
 
 // --- Passage ---
 
+export interface SourceLocation {
+  readonly file: string;
+  readonly line: number;
+}
+
 export interface PassageMetadata {
   position?: string;
   size?: string;
@@ -100,6 +107,7 @@ export interface Passage {
   tags: string[];
   text: string;
   metadata?: PassageMetadata;
+  source?: SourceLocation;
 }
 
 // --- Story ---
@@ -208,4 +216,5 @@ export interface TweeTsConfig {
   testMode?: boolean;
   noRemote?: boolean;
   tagAliases?: Record<string, string>;
+  sourceInfo?: boolean;
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -88,6 +88,11 @@ describe('validateConfig', () => {
     expect(errors).toContain('"tagAliases.library" must be a string.');
   });
 
+  it('rejects wrong type for sourceInfo', () => {
+    const errors = validateConfig({ sourceInfo: 'not-a-bool' });
+    expect(errors).toContain('"sourceInfo" must be a boolean.');
+  });
+
   it('accepts valid outputMode values', () => {
     for (const mode of ['html', 'twee3', 'twee1', 'twine2-archive', 'twine1-archive', 'json']) {
       const errors = validateConfig({ outputMode: mode });

--- a/test/fixtures/subfolder/intro.tw
+++ b/test/fixtures/subfolder/intro.tw
@@ -1,0 +1,15 @@
+:: StoryData
+{
+	"ifid": "D674C58C-DEFA-4F70-B7A2-27742230C0FC"
+}
+
+:: StoryTitle
+Source Info Test
+
+:: Start
+Welcome to the source info test.
+
+[[Next->Chapter]]
+
+:: Chapter
+This is a chapter.

--- a/test/fixtures/subfolder/nested/chapter1.tw
+++ b/test/fixtures/subfolder/nested/chapter1.tw
@@ -1,0 +1,5 @@
+:: DeepPassage
+This passage is in a nested subfolder.
+
+:: AnotherDeep [location]
+Another nested passage.

--- a/test/source-info.test.ts
+++ b/test/source-info.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { join, relative } from 'node:path';
+import { parseTwee } from '../src/parser.js';
+import { passageToPassagedata } from '../src/passage.js';
+import { compile } from '../src/compiler.js';
+import type { Passage } from '../src/types.js';
+
+const FIXTURES_DIR = join(__dirname, 'fixtures');
+const SUBFOLDER_DIR = join(FIXTURES_DIR, 'subfolder');
+const FORMAT_DIR = join(FIXTURES_DIR, 'storyformats');
+
+describe('parser source location', () => {
+  it('populates source with correct file and line for a single passage', () => {
+    const { passages } = parseTwee(':: Start\nHello!', { filename: 'test.tw' });
+    expect(passages).toHaveLength(1);
+    expect(passages[0]?.source).toEqual({ file: 'test.tw', line: 1 });
+  });
+
+  it('assigns correct source.line to each passage in a multi-passage file', () => {
+    const source = `:: First
+Content one.
+
+:: Second
+Content two.
+
+:: Third
+Content three.`;
+    const { passages } = parseTwee(source, { filename: 'multi.tw' });
+    expect(passages).toHaveLength(3);
+    expect(passages[0]?.source).toEqual({ file: 'multi.tw', line: 1 });
+    expect(passages[1]?.source).toEqual({ file: 'multi.tw', line: 4 });
+    expect(passages[2]?.source).toEqual({ file: 'multi.tw', line: 7 });
+  });
+
+  it('uses the provided filename in source.file', () => {
+    const { passages } = parseTwee(':: P\nText', { filename: 'custom/path.tw' });
+    expect(passages[0]?.source?.file).toBe('custom/path.tw');
+  });
+
+  it('defaults source.file to <inline> when no filename given', () => {
+    const { passages } = parseTwee(':: P\nText');
+    expect(passages[0]?.source?.file).toBe('<inline>');
+  });
+});
+
+describe('passageToPassagedata source info', () => {
+  const basePassage: Passage = {
+    name: 'Test',
+    tags: [],
+    text: 'Hello',
+    source: { file: 'src/story.tw', line: 42 },
+  };
+
+  it('emits data-source-file and data-source-line when sourceInfo is true', () => {
+    const html = passageToPassagedata(basePassage, 1, { sourceInfo: true });
+    expect(html).toContain('data-source-file="src/story.tw"');
+    expect(html).toContain('data-source-line="42"');
+  });
+
+  it('omits data- attrs when sourceInfo is false', () => {
+    const html = passageToPassagedata(basePassage, 1, { sourceInfo: false });
+    expect(html).not.toContain('data-source-file');
+    expect(html).not.toContain('data-source-line');
+  });
+
+  it('omits data- attrs when sourceInfo is not provided', () => {
+    const html = passageToPassagedata(basePassage, 1);
+    expect(html).not.toContain('data-source-file');
+    expect(html).not.toContain('data-source-line');
+  });
+
+  it('omits data- attrs when source is undefined (synthetic passages)', () => {
+    const synthetic: Passage = { name: 'Synth', tags: [], text: 'Generated' };
+    const html = passageToPassagedata(synthetic, 1, { sourceInfo: true });
+    expect(html).not.toContain('data-source-file');
+    expect(html).not.toContain('data-source-line');
+  });
+
+  it('escapes special characters in file paths', () => {
+    const p: Passage = {
+      name: 'Test',
+      tags: [],
+      text: 'Hello',
+      source: { file: 'path/with "quotes" & <angles>.tw', line: 1 },
+    };
+    const html = passageToPassagedata(p, 1, { sourceInfo: true });
+    expect(html).toContain('data-source-file=');
+    expect(html).not.toContain('path/with "quotes"');
+    expect(html).toContain('&amp;');
+  });
+});
+
+describe('compile with sourceInfo', () => {
+  it('includes data-source-file attributes when sourceInfo is true', async () => {
+    const result = await compile({
+      sources: [join(SUBFOLDER_DIR, 'intro.tw')],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+      sourceInfo: true,
+    });
+
+    expect(result.output).toContain('data-source-file=');
+    expect(result.output).toContain('data-source-line=');
+    // File path should be cwd-relative
+    const relPath = relative(process.cwd(), join(SUBFOLDER_DIR, 'intro.tw'));
+    expect(result.output).toContain(relPath);
+  });
+
+  it('omits data-source-* attributes when sourceInfo is not set', async () => {
+    const result = await compile({
+      sources: [join(SUBFOLDER_DIR, 'intro.tw')],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+    });
+
+    expect(result.output).not.toContain('data-source-file');
+    expect(result.output).not.toContain('data-source-line');
+  });
+
+  it('includes subfolder paths in data-source-file', async () => {
+    const result = await compile({
+      sources: [SUBFOLDER_DIR],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+      sourceInfo: true,
+    });
+
+    const nestedRelPath = relative(process.cwd(), join(SUBFOLDER_DIR, 'nested', 'chapter1.tw'));
+    expect(result.output).toContain(nestedRelPath);
+  });
+
+  it('uses the provided filename for inline sources', async () => {
+    const result = await compile({
+      sources: [
+        {
+          filename: 'my-inline.tw',
+          content: `:: StoryData
+{"ifid": "D674C58C-DEFA-4F70-B7A2-27742230C0FC"}
+
+:: StoryTitle
+Inline Test
+
+:: Start
+Hello from inline!`,
+        },
+      ],
+      formatId: 'test-format-1',
+      formatPaths: [FORMAT_DIR],
+      useTweegoPath: false,
+      sourceInfo: true,
+    });
+
+    expect(result.output).toContain('data-source-file="my-inline.tw"');
+  });
+});


### PR DESCRIPTION
Closes #13

## Summary
- Source location tracking for passages — parser records source file and line on every parsed passage (`Passage.source`)
- `--source-info` CLI flag and `sourceInfo` compile option to emit `data-source-file` and `data-source-line` attributes on `<tw-passagedata>` elements in HTML output
- `SourceLocation` type exported from the public API

## Checklist
- [x] Tests pass (`pnpm test` — 1071 tests)
- [x] Type check passes (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm run build`)
- [x] Formatting clean (`pnpm run format:check`)
- [x] CHANGELOG.md updated with v1.5.0

## Release
Merging this PR will trigger `release-npm-action` to publish v1.5.0 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)