### PR TITLE
release: v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-03-06
+
+### Changed
+
+- Passage lookups (`storyHas`, `storyGet`, `storyIndex`) now use an O(1) name index instead of linear scans, improving performance for large projects ([#27](https://github.com/rohal12/twee-ts/issues/27))
+
 ## [1.5.0] - 2026-03-06
 
 ### Added

--- a/src/story.ts
+++ b/src/story.ts
@@ -6,8 +6,25 @@ import type { Story, Passage, Diagnostic } from './types.js';
 import { validateIFID } from './ifid.js';
 import { isStoryPassage, countWords } from './passage.js';
 
+/** Module-level index: maps passage names to their array indices for O(1) lookups. */
+const passageIndex = new WeakMap<Story, Map<string, number>>();
+
+function getIndex(story: Story): Map<string, number> {
+  let index = passageIndex.get(story);
+  if (!index) {
+    // Rebuild for stories not created via createStory() (e.g., tests, external code)
+    index = new Map();
+    for (let i = 0; i < story.passages.length; i++) {
+      const passage = story.passages[i];
+      if (passage) index.set(passage.name, i);
+    }
+    passageIndex.set(story, index);
+  }
+  return index;
+}
+
 export function createStory(): Story {
-  return {
+  const story: Story = {
     name: '',
     ifid: '',
     passages: [],
@@ -23,23 +40,28 @@ export function createStory(): Story {
       zoom: 1,
     },
   };
+  passageIndex.set(story, new Map());
+  return story;
 }
 
 export function storyHas(story: Story, name: string): boolean {
-  return story.passages.some((p) => p.name === name);
+  return getIndex(story).has(name);
 }
 
 export function storyIndex(story: Story, name: string): number {
-  return story.passages.findIndex((p) => p.name === name);
+  return getIndex(story).get(name) ?? -1;
 }
 
 export function storyGet(story: Story, name: string): Passage | undefined {
-  return story.passages.find((p) => p.name === name);
+  const i = storyIndex(story, name);
+  return i === -1 ? undefined : story.passages[i];
 }
 
 export function storyAppend(story: Story, p: Passage, diagnostics: Diagnostic[]): void {
-  const i = storyIndex(story, p.name);
+  const index = getIndex(story);
+  const i = index.get(p.name) ?? -1;
   if (i === -1) {
+    index.set(p.name, story.passages.length);
     story.passages.push(p);
   } else {
     diagnostics.push({
@@ -51,9 +73,16 @@ export function storyAppend(story: Story, p: Passage, diagnostics: Diagnostic[])
 }
 
 export function storyPrepend(story: Story, p: Passage, diagnostics: Diagnostic[]): void {
-  const i = storyIndex(story, p.name);
+  const index = getIndex(story);
+  const i = index.get(p.name) ?? -1;
   if (i === -1) {
     story.passages.unshift(p);
+    // Rebuild index: unshift shifts all existing indices by 1
+    index.clear();
+    for (let j = 0; j < story.passages.length; j++) {
+      const passage = story.passages[j];
+      if (passage) index.set(passage.name, j);
+    }
   } else {
     diagnostics.push({
       level: 'warning',

--- a/test/story.test.ts
+++ b/test/story.test.ts
@@ -4,6 +4,7 @@ import {
   storyHas,
   storyGet,
   storyAdd,
+  storyPrepend,
   marshalStoryData,
   unmarshalStoryData,
   unmarshalStorySettings,
@@ -70,6 +71,33 @@ describe('Story', () => {
     expect(story.twine2.format).toBe('SugarCube');
     expect(story.twine2.formatVersion).toBe('2.37.3');
     expect(story.twine2.start).toBe('Begin');
+  });
+
+  it('lookups work after storyPrepend', () => {
+    const story = createStory();
+    const diag: Diagnostic[] = [];
+    storyAdd(story, mkPassage('A', 'alpha'), diag);
+    storyAdd(story, mkPassage('B', 'beta'), diag);
+    storyPrepend(story, mkPassage('Z', 'zulu'), diag);
+    expect(story.passages).toHaveLength(3);
+    expect(storyHas(story, 'Z')).toBe(true);
+    expect(storyHas(story, 'A')).toBe(true);
+    expect(storyHas(story, 'B')).toBe(true);
+    expect(storyGet(story, 'Z')?.text).toBe('zulu');
+    expect(storyGet(story, 'A')?.text).toBe('alpha');
+    expect(storyGet(story, 'B')?.text).toBe('beta');
+    expect(story.passages[0].name).toBe('Z');
+  });
+
+  it('storyPrepend replaces existing passage in place', () => {
+    const story = createStory();
+    const diag: Diagnostic[] = [];
+    storyAdd(story, mkPassage('A', 'first'), diag);
+    storyAdd(story, mkPassage('B', 'second'), diag);
+    storyPrepend(story, mkPassage('A', 'replaced'), diag);
+    expect(story.passages).toHaveLength(2);
+    expect(storyGet(story, 'A')?.text).toBe('replaced');
+    expect(diag.some((d) => d.message.includes('duplicate'))).toBe(true);
   });
 
   it('warns on StoryIncludes', () => {


### PR DESCRIPTION
## Summary
- Passage lookups (`storyHas`, `storyGet`, `storyIndex`) now use a `WeakMap`-backed name index for O(1) lookups instead of linear array scans
- Improves performance for large projects (e.g. CleanSlate with 605 passages) where `storyAppend` calls `storyIndex` on every passage load
- Added focused tests for `storyPrepend` verifying lookups work after prepend and duplicate replacement

Closes #27

## Checklist
- [x] Tests pass (`pnpm test` — 1073 tests)
- [x] Type check passes (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm run build`)
- [x] Formatting clean (`pnpm run format:check`)
- [x] CHANGELOG.md updated with new version
- [x] CleanSlate real-world compilation verified

## Release
Merging this PR will trigger `release-npm-action` to publish v1.5.1 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)