### PR TITLE
release: v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-03-06
+
+### Added
+
+- `--lint` CLI flag for linting story structure without producing output — reports broken links, dead ends, orphans, and compilation diagnostics ([#16](https://github.com/rohal12/twee-ts/issues/16), [#20](https://github.com/rohal12/twee-ts/issues/20))
+- `lint()` and `formatLintReport()` programmatic API functions for CI/CD integration
+- `LintResult` type exported from the public API
+- Exit code 1 when lint finds errors (broken links, compilation errors); warnings do not cause non-zero exit
+
 ## [1.6.0] - 2026-03-06
 
 ### Added

--- a/bin/twee-ts.ts
+++ b/bin/twee-ts.ts
@@ -6,6 +6,7 @@ import { parseArgs } from 'node:util';
 import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { compile, compileToFile, watch } from '../src/compiler.js';
+import { lint, formatLintReport } from '../src/lint.js';
 import { discoverFormats, getFormatSearchDirs } from '../src/formats.js';
 import { loadConfig, loadConfigFile, scaffoldConfig, CONFIG_FILENAME } from '../src/config.js';
 import { discoverCachedFormats } from '../src/remote-formats.js';
@@ -27,6 +28,7 @@ const { values, positionals } = parseArgs({
     'archive-twine1': { type: 'boolean' },
     'twee2-compat': { type: 'boolean' },
     'no-trim': { type: 'boolean' },
+    lint: { type: 'boolean' },
     test: { type: 'boolean', short: 't' },
     watch: { type: 'boolean', short: 'w' },
     'log-stats': { type: 'boolean', short: 'l' },
@@ -106,6 +108,29 @@ async function main(): Promise<void> {
       }
       tagAliases[pair.slice(0, eq)] = pair.slice(eq + 1);
     }
+  }
+
+  // Lint mode: compile + inspect, no output
+  if (values.lint) {
+    const lintResult = await lint({
+      sources,
+      formatId: values.format ?? config?.formatId,
+      startPassage: values.start ?? config?.startPassage,
+      formatPaths: config?.formatPaths,
+      modules: values.module ?? config?.modules,
+      headFile: values.head ?? config?.headFile,
+      trim: values['no-trim'] ? false : (config?.trim ?? true),
+      twee2Compat: values['twee2-compat'] ?? config?.twee2Compat ?? false,
+      testMode: values.test ?? config?.testMode ?? false,
+      formatIndices: values['format-index'] ?? config?.formatIndices,
+      formatUrls: values['format-url'] ?? config?.formatUrls,
+      noRemote: values['no-remote'] ?? config?.noRemote ?? false,
+      tagAliases,
+      sourceInfo: values['source-info'] ?? config?.sourceInfo ?? false,
+    });
+    console.log(formatLintReport(lintResult));
+    const hasErrors = lintResult.brokenLinks.length > 0 || lintResult.diagnostics.some((d) => d.level === 'error');
+    process.exit(hasErrors ? 1 : 0);
   }
 
   const compileOptions = {
@@ -254,6 +279,7 @@ Options:
   --archive-twine1          Output as Twine 1 archive
   --json                    Output as JSON
   --twee2-compat            Enable Twee2 syntax compatibility
+  --lint                    Lint story structure (broken links, dead ends, orphans)
   --no-trim                 Don't trim passage whitespace
   -t, --test                Enable test/debug mode
   -w, --watch               Watch for changes and rebuild

--- a/docs/api.md
+++ b/docs/api.md
@@ -236,6 +236,21 @@ const errors = validateConfig({ sources: 42 }); // validation
 const json = scaffoldConfig(); // default config JSON
 ```
 
+### Lint
+
+```typescript
+import { lint, formatLintReport } from '@rohal12/twee-ts';
+
+const result = await lint({ sources: ['src/'] });
+
+console.log(result.brokenLinks); // [{ from: 'Kitchen', to: 'Pantry' }]
+console.log(result.deadEnds); // ['Ending1', 'Ending2']
+console.log(result.orphans); // ['UnusedRoom']
+
+// Human-readable report
+console.log(formatLintReport(result));
+```
+
 ### Story Inspection
 
 ```typescript
@@ -273,5 +288,6 @@ import type {
   SFAIndexEntry,
   SourceLocation,
   TweeTsConfig,
+  LintResult,
 } from '@rohal12/twee-ts';
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,30 @@ See [Output Modes](./output-modes) for details on each mode.
 
 See [Format Discovery](./story-formats) for how formats are located.
 
+### Linting
+
+| Flag     | Description                                                             |
+| -------- | ----------------------------------------------------------------------- |
+| `--lint` | Lint story structure (broken links, dead ends, orphans) without output. |
+
+Exits with code 1 if errors are found (broken links, compilation errors). Warnings (dead ends, orphans) do not cause a non-zero exit.
+
+```sh
+$ twee-ts --lint ./story/
+Format: SugarCube 2.37.3
+Passages: 42 total (38 story, 4 info), 12,345 words, 15 files
+Start: Start
+
+Broken links (1):
+  Kitchen -> Pantry (passage "Pantry" does not exist)
+
+Dead ends (2): Ending1, Ending2
+
+Orphans (1): UnusedRoom
+
+Lint failed.
+```
+
 ### Watch & Logging
 
 | Flag              | Description                                                        |

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,9 @@ export { compile, compileToFile, watch, TweeTsError } from './compiler.js';
 // Story inspection (for unit testing)
 export { storyInspect } from './inspect.js';
 
+// Lint
+export { lint, formatLintReport } from './lint.js';
+
 // Passage utilities
 export { applyTagAliases } from './passage.js';
 
@@ -53,3 +56,4 @@ export type {
   TweeTsConfig,
 } from './types.js';
 export type { StoryMap, BrokenLink } from './inspect.js';
+export type { LintResult } from './lint.js';

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,0 +1,120 @@
+/**
+ * Lint mode: compile + inspect story structure without producing output.
+ * Surfaces broken links, dead ends, orphans, and compilation diagnostics.
+ */
+import type { CompileOptions, CompileStats, Diagnostic } from './types.js';
+import type { BrokenLink } from './inspect.js';
+import { compile } from './compiler.js';
+import { storyInspect } from './inspect.js';
+
+export interface LintResult {
+  /** Compilation diagnostics (errors and warnings). */
+  diagnostics: Diagnostic[];
+  /** Compilation statistics. */
+  stats: CompileStats;
+  /** Story format name from StoryData (e.g. "SugarCube"). */
+  formatName: string;
+  /** Story format version from StoryData (e.g. "2.37.3"). */
+  formatVersion: string;
+  /** The configured start passage name. */
+  start: string;
+  /** Total passage count. */
+  passages: number;
+  /** Story passage count (excludes StoryData, StoryTitle, scripts, etc.). */
+  storyPassages: number;
+  /** Info/special passage count. */
+  infoPassages: number;
+  /** Broken links: link targets that don't exist as passages. */
+  brokenLinks: BrokenLink[];
+  /** Story passages with no outgoing links. */
+  deadEnds: string[];
+  /** Story passages that no other passage links to. */
+  orphans: string[];
+}
+
+/**
+ * Lint a story: compile without output rendering, then inspect structure.
+ * Uses JSON output mode internally to avoid format resolution.
+ */
+export async function lint(options: Omit<CompileOptions, 'outputMode'>): Promise<LintResult> {
+  const result = await compile({ ...options, outputMode: 'json' });
+  const map = storyInspect(result.story);
+
+  return {
+    diagnostics: result.diagnostics,
+    stats: result.stats,
+    formatName: result.story.twine2.format,
+    formatVersion: result.story.twine2.formatVersion,
+    start: map.start,
+    passages: map.passages.length,
+    storyPassages: map.storyPassages.length,
+    infoPassages: map.infoPassages.length,
+    brokenLinks: map.brokenLinks,
+    deadEnds: map.deadEnds,
+    orphans: map.orphans,
+  };
+}
+
+/**
+ * Format a lint result as a human-readable report string.
+ */
+export function formatLintReport(result: LintResult): string {
+  const lines: string[] = [];
+
+  // Header: format and stats
+  const formatStr = result.formatName
+    ? `${result.formatName}${result.formatVersion ? ' ' + result.formatVersion : ''}`
+    : 'unknown';
+  lines.push(`Format: ${formatStr}`);
+  lines.push(
+    `Passages: ${result.passages} total (${result.storyPassages} story, ${result.infoPassages} info), ${result.stats.words.toLocaleString()} words, ${result.stats.files.length} files`,
+  );
+  lines.push(`Start: ${result.start}`);
+
+  // Broken links (errors)
+  if (result.brokenLinks.length > 0) {
+    lines.push('');
+    lines.push(`Broken links (${result.brokenLinks.length}):`);
+    for (const link of result.brokenLinks) {
+      lines.push(`  ${link.from} -> ${link.to} (passage "${link.to}" does not exist)`);
+    }
+  }
+
+  // Dead ends (warnings)
+  if (result.deadEnds.length > 0) {
+    lines.push('');
+    lines.push(`Dead ends (${result.deadEnds.length}): ${result.deadEnds.join(', ')}`);
+  }
+
+  // Orphans (warnings)
+  if (result.orphans.length > 0) {
+    lines.push('');
+    lines.push(`Orphans (${result.orphans.length}): ${result.orphans.join(', ')}`);
+  }
+
+  // Compilation diagnostics
+  const errors = result.diagnostics.filter((d) => d.level === 'error');
+  const warnings = result.diagnostics.filter((d) => d.level === 'warning');
+
+  if (errors.length > 0 || warnings.length > 0) {
+    lines.push('');
+    lines.push(`Diagnostics: ${errors.length} error(s), ${warnings.length} warning(s)`);
+    for (const d of errors) {
+      lines.push(`  error: ${d.message}`);
+    }
+    for (const d of warnings) {
+      lines.push(`  warning: ${d.message}`);
+    }
+  }
+
+  // Summary line
+  lines.push('');
+  const hasErrors = errors.length > 0 || result.brokenLinks.length > 0;
+  if (hasErrors) {
+    lines.push('Lint failed.');
+  } else {
+    lines.push('Lint passed.');
+  }
+
+  return lines.join('\n');
+}

--- a/test/lint.test.ts
+++ b/test/lint.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { lint, formatLintReport } from '../src/lint.js';
+
+const FIXTURES_DIR = join(__dirname, 'fixtures');
+
+describe('lint', () => {
+  it('reports stats for a clean story', async () => {
+    const result = await lint({
+      sources: [join(FIXTURES_DIR, 'multi-passage.tw')],
+    });
+
+    expect(result.passages).toBeGreaterThan(0);
+    expect(result.storyPassages).toBeGreaterThan(0);
+    expect(result.stats.words).toBeGreaterThan(0);
+    expect(result.stats.files.length).toBe(1);
+    expect(result.start).toBe('Start');
+  });
+
+  it('detects broken links', async () => {
+    const result = await lint({
+      sources: [
+        {
+          filename: 'broken.tw',
+          content:
+            ':: StoryData\n{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}\n\n:: Start\n[[Go->MissingRoom]]\n\n:: Room\nSafe passage',
+        },
+      ],
+    });
+
+    expect(result.brokenLinks).toHaveLength(1);
+    expect(result.brokenLinks[0]).toEqual({ from: 'Start', to: 'MissingRoom' });
+  });
+
+  it('detects dead ends and orphans', async () => {
+    const result = await lint({
+      sources: [join(FIXTURES_DIR, 'multi-passage.tw')],
+    });
+
+    expect(result.deadEnds).toContain('Secret Room');
+    expect(result.deadEnds).toContain('Ending');
+    expect(result.orphans).toContain('Secret Room');
+    expect(result.orphans).toContain('Ending');
+  });
+
+  it('reads format info from StoryData', async () => {
+    const result = await lint({
+      sources: [
+        {
+          filename: 'format.tw',
+          content:
+            ':: StoryData\n{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube","format-version":"2.37.3"}\n\n:: Start\nHello',
+        },
+      ],
+    });
+
+    expect(result.formatName).toBe('SugarCube');
+    expect(result.formatVersion).toBe('2.37.3');
+  });
+});
+
+describe('formatLintReport', () => {
+  it('shows pass for clean story', async () => {
+    const result = await lint({
+      sources: [
+        {
+          filename: 'clean.tw',
+          content:
+            ':: StoryData\n{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC","format":"SugarCube","format-version":"2.37.3"}\n\n:: Start\n[[Room]]\n\n:: Room\n[[Start]]',
+        },
+      ],
+    });
+
+    const report = formatLintReport(result);
+    expect(report).toContain('Format: SugarCube 2.37.3');
+    expect(report).toContain('Lint passed.');
+    expect(report).not.toContain('Broken links');
+  });
+
+  it('shows fail for broken links', async () => {
+    const result = await lint({
+      sources: [
+        {
+          filename: 'broken.tw',
+          content: ':: StoryData\n{"ifid":"D674C58C-DEFA-4F70-B7A2-27742230C0FC"}\n\n:: Start\n[[Missing]]',
+        },
+      ],
+    });
+
+    const report = formatLintReport(result);
+    expect(report).toContain('Broken links');
+    expect(report).toContain('Start -> Missing');
+    expect(report).toContain('Lint failed.');
+  });
+
+  it('shows dead ends and orphans', async () => {
+    const result = await lint({
+      sources: [join(FIXTURES_DIR, 'multi-passage.tw')],
+    });
+
+    const report = formatLintReport(result);
+    expect(report).toContain('Dead ends');
+    expect(report).toContain('Orphans');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--lint` CLI flag for story structure linting (broken links, dead ends, orphans, diagnostics)
- Add `lint()` and `formatLintReport()` programmatic API
- Exit code 1 on errors for CI/CD pipeline integration
- Closes #16 (`--lint` / `--check` CLI mode) and #20 (`--dry-run` preview mode) — combined into a single `--lint` feature

## Checklist
- [x] Tests pass (`pnpm test`) — 1090 tests, 7 new
- [x] Type check passes (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm run build`)
- [x] Formatting clean (`pnpm run format:check`)
- [x] CHANGELOG.md updated with v1.7.0
- [x] CLI docs updated (`docs/cli.md`)
- [x] API docs updated (`docs/api.md`)

## Release
Merging this PR will trigger `release-npm-action` to publish v1.7.0 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)