### PR TITLE
feat: cache management CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-03-06
+
+### Added
+
+- `twee-ts cache` CLI subcommand for managing the remote format cache ([#24](https://github.com/rohal12/twee-ts/issues/24)):
+  - `cache list` — list cached formats with name, version, size, and modification date
+  - `cache clear [name]` — delete all cached formats or only those matching a name
+  - `cache size` — show total cache size and format count
+  - `cache path` — print the cache directory path
+- `listCachedFormats()`, `clearCachedFormats()`, `getCacheSize()` programmatic API functions
+- `CachedFormatEntry` type exported from the public API
+
 ## [1.7.0] - 2026-03-06
 
 ### Added

--- a/bin/twee-ts.ts
+++ b/bin/twee-ts.ts
@@ -9,7 +9,13 @@ import { compile, compileToFile, watch } from '../src/compiler.js';
 import { lint, formatLintReport } from '../src/lint.js';
 import { discoverFormats, getFormatSearchDirs } from '../src/formats.js';
 import { loadConfig, loadConfigFile, scaffoldConfig, CONFIG_FILENAME } from '../src/config.js';
-import { discoverCachedFormats } from '../src/remote-formats.js';
+import {
+  discoverCachedFormats,
+  getCacheDir,
+  listCachedFormats,
+  clearCachedFormats,
+  getCacheSize,
+} from '../src/remote-formats.js';
 import type { TweeTsConfig, OutputMode } from '../src/types.js';
 
 import { VERSION } from '../src/version.js';
@@ -67,6 +73,11 @@ async function main(): Promise<void> {
 
   if (values.init) {
     runInit();
+    return;
+  }
+
+  if (positionals[0] === 'cache') {
+    runCache(positionals.slice(1));
     return;
   }
 
@@ -262,6 +273,66 @@ This is the starting passage. Edit this file to begin writing your story.
   console.log('\nRun: npx @rohal12/twee-ts');
 }
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)}K`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)}M`;
+}
+
+function runCache(args: string[]): void {
+  const subcommand = args[0];
+
+  switch (subcommand) {
+    case 'list': {
+      const entries = listCachedFormats();
+      if (entries.length === 0) {
+        console.log('No cached formats.');
+        return;
+      }
+      for (const e of entries) {
+        const date = e.modifiedAt.toISOString().slice(0, 10);
+        console.log(`${e.name.padEnd(16)} ${e.version.padEnd(10)} ${formatBytes(e.sizeBytes).padStart(6)}   ${date}`);
+      }
+      return;
+    }
+    case 'clear': {
+      const name = args[1];
+      const count = clearCachedFormats(name);
+      if (count === 0) {
+        console.log(name ? `No cached formats matching "${name}".` : 'Cache is already empty.');
+      } else {
+        console.log(`Cleared ${count} cached format${count === 1 ? '' : 's'}.`);
+      }
+      return;
+    }
+    case 'size': {
+      const { totalBytes, count } = getCacheSize();
+      if (count === 0) {
+        console.log('Cache is empty.');
+      } else {
+        console.log(`Total: ${formatBytes(totalBytes)} (${count} format${count === 1 ? '' : 's'})`);
+      }
+      return;
+    }
+    case 'path': {
+      console.log(getCacheDir());
+      return;
+    }
+    default: {
+      console.error(`Usage: twee-ts cache <list|clear|size|path>
+
+  list          List cached formats with name, version, size
+  clear         Delete all cached formats
+  clear <name>  Delete cached formats matching name
+  size          Show total cache size
+  path          Print cache directory path`);
+      process.exit(subcommand ? 1 : 0);
+    }
+  }
+}
+
 function printUsage(): void {
   console.log(`twee-ts v${VERSION} — TypeScript Twee-to-HTML compiler
 
@@ -295,7 +366,13 @@ Options:
   -c, --config <file>       Config file path (default: ${CONFIG_FILENAME})
   --no-config               Skip config file loading
   -h, --help                Show this help
-  -v, --version             Show version`);
+  -v, --version             Show version
+
+Subcommands:
+  cache list                List cached remote formats
+  cache clear [name]        Clear cached formats (all or by name)
+  cache size                Show total cache size
+  cache path                Print cache directory path`);
 }
 
 main().catch((err: unknown) => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -207,13 +207,39 @@ for (const [id, format] of formats) {
 ### Remote Formats
 
 ```typescript
-import { resolveRemoteFormat, fetchAndCacheFormat, discoverCachedFormats } from '@rohal12/twee-ts';
+import {
+  resolveRemoteFormat,
+  fetchAndCacheFormat,
+  discoverCachedFormats,
+  listCachedFormats,
+  clearCachedFormats,
+  getCacheSize,
+  getCacheDir,
+} from '@rohal12/twee-ts';
 
 // Auto-resolve from SFA indices
 const format = await resolveRemoteFormat('SugarCube', '2.37.3');
 
-// List cached formats
+// List cached formats (Map<id, StoryFormatInfo>)
 const cached = discoverCachedFormats();
+
+// List cached formats with size and modification date
+const entries = listCachedFormats();
+for (const e of entries) {
+  console.log(`${e.name} ${e.version} — ${e.sizeBytes} bytes, modified ${e.modifiedAt.toISOString()}`);
+}
+
+// Clear all cached formats (returns count removed)
+clearCachedFormats();
+
+// Clear cached formats by name
+clearCachedFormats('SugarCube');
+
+// Get total cache size
+const { totalBytes, count } = getCacheSize();
+
+// Get cache directory path
+const cacheDir = getCacheDir();
 ```
 
 ### IFID
@@ -289,5 +315,6 @@ import type {
   SourceLocation,
   TweeTsConfig,
   LintResult,
+  CachedFormatEntry,
 } from '@rohal12/twee-ts';
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,6 +104,38 @@ Lint failed.
 | `-h, --help`    | Show help text. |
 | `-v, --version` | Show version.   |
 
+### Cache Management
+
+Manage the local cache of downloaded remote story formats.
+
+```
+twee-ts cache <subcommand>
+```
+
+| Subcommand     | Description                                             |
+| -------------- | ------------------------------------------------------- |
+| `list`         | List cached formats with name, version, size, and date. |
+| `clear`        | Delete all cached formats.                              |
+| `clear <name>` | Delete cached formats matching a name.                  |
+| `size`         | Show total cache size and format count.                 |
+| `path`         | Print the cache directory path.                         |
+
+```sh
+$ twee-ts cache list
+SugarCube         2.37.3       245K   2026-02-15
+Harlowe           3.3.9        512K   2026-01-20
+Chapbook          2.2.0        189K   2026-03-01
+
+$ twee-ts cache size
+Total: 946K (3 formats)
+
+$ twee-ts cache clear Harlowe
+Cleared 1 cached format.
+
+$ twee-ts cache path
+/home/user/.cache/twee-ts/storyformats
+```
+
 ## Examples
 
 ```sh

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,9 @@ export {
   fetchDirectFormat,
   getCacheDir,
   discoverCachedFormats,
+  listCachedFormats,
+  clearCachedFormats,
+  getCacheSize,
 } from './remote-formats.js';
 
 // Types
@@ -55,5 +58,6 @@ export type {
   SourceLocation,
   TweeTsConfig,
 } from './types.js';
+export type { CachedFormatEntry } from './remote-formats.js';
 export type { StoryMap, BrokenLink } from './inspect.js';
 export type { LintResult } from './lint.js';

--- a/src/remote-formats.ts
+++ b/src/remote-formats.ts
@@ -2,7 +2,7 @@
  * Remote story format fetching, caching, and checksum verification.
  * Uses the Story Formats Archive (SFA) as the default source.
  */
-import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, statSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { SFAIndex, SFAIndexEntry, StoryFormatInfo } from './types.js';
@@ -326,4 +326,97 @@ export function discoverCachedFormats(): Map<string, StoryFormatInfo> {
   }
 
   return formats;
+}
+
+/** Info about a cached format entry with size and modification date. */
+export interface CachedFormatEntry {
+  readonly name: string;
+  readonly version: string;
+  readonly sizeBytes: number;
+  readonly modifiedAt: Date;
+}
+
+/** List all cached formats with size and modification date. */
+export function listCachedFormats(): readonly CachedFormatEntry[] {
+  const cacheDir = getCacheDir();
+  const entries: CachedFormatEntry[] = [];
+
+  try {
+    if (!existsSync(cacheDir)) return entries;
+  } catch {
+    return entries;
+  }
+
+  let names: string[];
+  try {
+    names = readdirSync(cacheDir);
+  } catch {
+    return entries;
+  }
+
+  for (const name of names) {
+    const nameDir = join(cacheDir, name);
+    try {
+      if (!statSync(nameDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    let versions: string[];
+    try {
+      versions = readdirSync(nameDir);
+    } catch {
+      continue;
+    }
+
+    for (const version of versions) {
+      const formatPath = join(nameDir, version, 'format.js');
+      try {
+        const stat = statSync(formatPath);
+        entries.push({
+          name,
+          version,
+          sizeBytes: stat.size,
+          modifiedAt: stat.mtime,
+        });
+      } catch {
+        // Skip entries without a valid format.js
+      }
+    }
+  }
+
+  return entries;
+}
+
+/** Clear all cached formats, or only those matching a given name. Returns the number of entries removed. */
+export function clearCachedFormats(name?: string): number {
+  const cacheDir = getCacheDir();
+  if (!existsSync(cacheDir)) return 0;
+
+  if (!name) {
+    const entries = listCachedFormats();
+    const count = entries.length;
+    rmSync(cacheDir, { recursive: true, force: true });
+    return count;
+  }
+
+  const nameDir = join(cacheDir, name);
+  if (!existsSync(nameDir)) return 0;
+
+  let versions: string[];
+  try {
+    versions = readdirSync(nameDir);
+  } catch {
+    return 0;
+  }
+  const count = versions.length;
+  rmSync(nameDir, { recursive: true, force: true });
+  return count;
+}
+
+/** Get total cache size in bytes and format count. */
+export function getCacheSize(): { totalBytes: number; count: number } {
+  const entries = listCachedFormats();
+  const totalBytes = entries.reduce((sum, e) => sum + e.sizeBytes, 0);
+  return { totalBytes, count: entries.length };
 }

--- a/test/remote-formats.test.ts
+++ b/test/remote-formats.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { getCacheDir, findEntry, verifySHA256, clearIndexCache, discoverCachedFormats } from '../src/remote-formats.js';
+import {
+  getCacheDir,
+  findEntry,
+  verifySHA256,
+  clearIndexCache,
+  discoverCachedFormats,
+  listCachedFormats,
+  clearCachedFormats,
+  getCacheSize,
+} from '../src/remote-formats.js';
 import type { SFAIndex, SFAIndexEntry } from '../src/types.js';
 
 // Minimal format.js content for testing
@@ -155,5 +164,176 @@ describe('discoverCachedFormats', () => {
         delete process.env['XDG_CACHE_HOME'];
       }
     }
+  });
+});
+
+/** Helper: set XDG_CACHE_HOME for a test, restore afterward. */
+function withCacheHome(tmpDir: string, fn: () => void): void {
+  const orig = process.env['XDG_CACHE_HOME'];
+  process.env['XDG_CACHE_HOME'] = tmpDir;
+  try {
+    fn();
+  } finally {
+    if (orig !== undefined) {
+      process.env['XDG_CACHE_HOME'] = orig;
+    } else {
+      delete process.env['XDG_CACHE_HOME'];
+    }
+  }
+}
+
+describe('listCachedFormats', () => {
+  const TMP_CACHE = join(__dirname, '.tmp-cache-list');
+
+  beforeEach(() => {
+    rmSync(TMP_CACHE, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(TMP_CACHE, { recursive: true, force: true });
+  });
+
+  it('lists cached formats with size and date', () => {
+    withCacheHome(TMP_CACHE, () => {
+      const cacheDir = getCacheDir();
+      const formatDir = join(cacheDir, 'MockFormat', '2.1.0');
+      mkdirSync(formatDir, { recursive: true });
+      writeFileSync(join(formatDir, 'format.js'), MOCK_FORMAT_SOURCE);
+
+      const entries = listCachedFormats();
+      expect(entries.length).toBe(1);
+      expect(entries[0]!.name).toBe('MockFormat');
+      expect(entries[0]!.version).toBe('2.1.0');
+      expect(entries[0]!.sizeBytes).toBeGreaterThan(0);
+      expect(entries[0]!.modifiedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  it('returns empty array when cache does not exist', () => {
+    withCacheHome(join(TMP_CACHE, 'nonexistent'), () => {
+      expect(listCachedFormats()).toEqual([]);
+    });
+  });
+
+  it('lists multiple formats', () => {
+    withCacheHome(TMP_CACHE, () => {
+      const cacheDir = getCacheDir();
+      for (const [name, version] of [
+        ['FormatA', '1.0.0'],
+        ['FormatB', '3.2.1'],
+      ] as const) {
+        const dir = join(cacheDir, name, version);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+          join(dir, 'format.js'),
+          `window.storyFormat({"name":"${name}","version":"${version}","proofing":false,"source":"<html></html>"});`,
+        );
+      }
+
+      const entries = listCachedFormats();
+      expect(entries.length).toBe(2);
+      const names = entries.map((e) => e.name).sort();
+      expect(names).toEqual(['FormatA', 'FormatB']);
+    });
+  });
+});
+
+describe('clearCachedFormats', () => {
+  const TMP_CACHE = join(__dirname, '.tmp-cache-clear');
+
+  beforeEach(() => {
+    rmSync(TMP_CACHE, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(TMP_CACHE, { recursive: true, force: true });
+  });
+
+  it('clears all cached formats', () => {
+    withCacheHome(TMP_CACHE, () => {
+      const cacheDir = getCacheDir();
+      const dir = join(cacheDir, 'MockFormat', '2.1.0');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'format.js'), MOCK_FORMAT_SOURCE);
+
+      const count = clearCachedFormats();
+      expect(count).toBe(1);
+      expect(listCachedFormats()).toEqual([]);
+    });
+  });
+
+  it('clears formats by name', () => {
+    withCacheHome(TMP_CACHE, () => {
+      const cacheDir = getCacheDir();
+      for (const [name, version] of [
+        ['FormatA', '1.0.0'],
+        ['FormatB', '3.2.1'],
+      ] as const) {
+        const dir = join(cacheDir, name, version);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+          join(dir, 'format.js'),
+          `window.storyFormat({"name":"${name}","version":"${version}","proofing":false,"source":"<html></html>"});`,
+        );
+      }
+
+      const count = clearCachedFormats('FormatA');
+      expect(count).toBe(1);
+
+      const remaining = listCachedFormats();
+      expect(remaining.length).toBe(1);
+      expect(remaining[0]!.name).toBe('FormatB');
+    });
+  });
+
+  it('returns 0 when cache does not exist', () => {
+    withCacheHome(join(TMP_CACHE, 'nonexistent'), () => {
+      expect(clearCachedFormats()).toBe(0);
+    });
+  });
+
+  it('returns 0 when name does not match', () => {
+    withCacheHome(TMP_CACHE, () => {
+      const cacheDir = getCacheDir();
+      const dir = join(cacheDir, 'MockFormat', '2.1.0');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'format.js'), MOCK_FORMAT_SOURCE);
+
+      expect(clearCachedFormats('NonExistent')).toBe(0);
+      expect(listCachedFormats().length).toBe(1);
+    });
+  });
+});
+
+describe('getCacheSize', () => {
+  const TMP_CACHE = join(__dirname, '.tmp-cache-size');
+
+  beforeEach(() => {
+    rmSync(TMP_CACHE, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(TMP_CACHE, { recursive: true, force: true });
+  });
+
+  it('returns total size and count', () => {
+    withCacheHome(TMP_CACHE, () => {
+      const cacheDir = getCacheDir();
+      const dir = join(cacheDir, 'MockFormat', '2.1.0');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'format.js'), MOCK_FORMAT_SOURCE);
+
+      const { totalBytes, count } = getCacheSize();
+      expect(count).toBe(1);
+      expect(totalBytes).toBe(MOCK_FORMAT_SOURCE.length);
+    });
+  });
+
+  it('returns zero for empty cache', () => {
+    withCacheHome(join(TMP_CACHE, 'nonexistent'), () => {
+      const { totalBytes, count } = getCacheSize();
+      expect(totalBytes).toBe(0);
+      expect(count).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `twee-ts cache` CLI subcommand for managing the remote story format cache (`list`, `clear [name]`, `size`, `path`)
- Adds `listCachedFormats()`, `clearCachedFormats()`, `getCacheSize()` programmatic API functions and `CachedFormatEntry` type
- 9 new tests covering all cache management functions
- Updated CLI and API docs, changelog entry for 1.8.0

Closes #24

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (1099 tests, 9 new)
- [x] `pnpm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)