### PR TITLE
release: v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-03-06
+
+### Added
+
+- JSON Schema for `twee-ts.config.json` — provides editor autocomplete and validation in VS Code, WebStorm, and other JSON Schema-aware editors ([#23](https://github.com/rohal12/twee-ts/issues/23))
+- `scaffoldConfig()` now emits a `$schema` field pointing to the published schema
+- Schema published alongside the npm package at `schemas/twee-ts.config.schema.json`
+
 ## [1.9.0] - 2026-03-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "twee-ts": "./dist/bin/twee-ts.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "schemas"
   ],
   "scripts": {
     "build": "tsup",

--- a/schemas/twee-ts.config.schema.json
+++ b/schemas/twee-ts.config.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://unpkg.com/@rohal12/twee-ts/schemas/twee-ts.config.schema.json",
+  "title": "twee-ts Configuration",
+  "description": "Configuration file for twee-ts, a TypeScript Twee-to-HTML compiler.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference for editor support."
+    },
+    "sources": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Files or directories to compile."
+    },
+    "output": {
+      "type": "string",
+      "description": "Output file path."
+    },
+    "outputMode": {
+      "type": "string",
+      "enum": ["html", "twee3", "twee1", "twine2-archive", "twine1-archive", "json"],
+      "default": "html",
+      "description": "Output mode."
+    },
+    "formatId": {
+      "type": "string",
+      "description": "Story format directory ID (e.g. 'sugarcube-2')."
+    },
+    "startPassage": {
+      "type": "string",
+      "description": "Name of the starting passage.",
+      "default": "Start"
+    },
+    "formatPaths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Extra directories to search for story formats."
+    },
+    "formatIndices": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "URLs to SFA-compatible index.json files for remote format lookup."
+    },
+    "formatUrls": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Direct URLs to format.js files."
+    },
+    "useTweegoPath": {
+      "type": "boolean",
+      "default": true,
+      "description": "Also search TWEEGO_PATH env for formats."
+    },
+    "modules": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Module files to inject into <head>."
+    },
+    "headFile": {
+      "type": "string",
+      "description": "Raw HTML file to append to <head>."
+    },
+    "trim": {
+      "type": "boolean",
+      "default": true,
+      "description": "Trim passage whitespace."
+    },
+    "twee2Compat": {
+      "type": "boolean",
+      "default": false,
+      "description": "Twee2 compatibility mode."
+    },
+    "testMode": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable debug/test mode option."
+    },
+    "noRemote": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable remote format fetching."
+    },
+    "tagAliases": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Map alias tags to canonical special tags (e.g. { \"library\": \"script\" })."
+    },
+    "sourceInfo": {
+      "type": "boolean",
+      "default": false,
+      "description": "Emit source file and line as data- attributes on passage elements."
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,7 +124,8 @@ export function validateConfig(data: unknown): string[] {
 
 /** Return a default config JSON string for --init scaffolding. */
 export function scaffoldConfig(): string {
-  const config: TweeTsConfig = {
+  const config = {
+    $schema: 'https://unpkg.com/@rohal12/twee-ts/schemas/twee-ts.config.schema.json',
     sources: ['src/'],
     output: 'story.html',
   };

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { validateConfig, loadConfig, scaffoldConfig, CONFIG_FILENAME } from '../src/config.js';
 
 const TMP_DIR = join(__dirname, '.tmp-config-test');
@@ -145,10 +145,52 @@ describe('loadConfig', () => {
 });
 
 describe('scaffoldConfig', () => {
-  it('returns valid JSON with sources and output', () => {
+  it('returns valid JSON with $schema, sources, and output', () => {
     const json = scaffoldConfig();
     const parsed = JSON.parse(json);
+    expect(parsed.$schema).toBe('https://unpkg.com/@rohal12/twee-ts/schemas/twee-ts.config.schema.json');
     expect(parsed.sources).toEqual(['src/']);
     expect(parsed.output).toBe('story.html');
+  });
+});
+
+describe('JSON Schema', () => {
+  it('is valid JSON and covers all TweeTsConfig fields', () => {
+    const schemaPath = join(__dirname, '..', 'schemas', 'twee-ts.config.schema.json');
+    const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
+
+    expect(schema.type).toBe('object');
+
+    const expectedFields = [
+      'sources',
+      'output',
+      'outputMode',
+      'formatId',
+      'startPassage',
+      'formatPaths',
+      'formatIndices',
+      'formatUrls',
+      'useTweegoPath',
+      'modules',
+      'headFile',
+      'trim',
+      'twee2Compat',
+      'testMode',
+      'noRemote',
+      'tagAliases',
+      'sourceInfo',
+    ];
+
+    for (const field of expectedFields) {
+      expect(schema.properties).toHaveProperty(field);
+    }
+  });
+
+  it('accepts $schema field in config validation', () => {
+    const errors = validateConfig({
+      $schema: 'https://unpkg.com/@rohal12/twee-ts/schemas/twee-ts.config.schema.json',
+      sources: ['src/'],
+    });
+    expect(errors).toEqual([]);
   });
 });


### PR DESCRIPTION
release-npm

Closes #23

## Summary
- JSON Schema for `twee-ts.config.json` — editor autocomplete and validation (#23)
- `scaffoldConfig()` emits `$schema` field
- Schema published alongside npm package at `schemas/twee-ts.config.schema.json`
- SchemaStore registration PR submitted: https://github.com/SchemaStore/schemastore/pull/5447

## Checklist
- [x] Tests pass (`pnpm test`)
- [x] Type check passes (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm run build`)
- [x] Formatting clean (`pnpm run format:check`)
- [x] CHANGELOG.md updated with new version

## Release
Merging this PR will trigger `release-npm-action` to publish v1.10.0 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)