### PR TITLE
release: v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-03-06
+
+### Added
+
+- Configurable word counting method via `wordCountMethod` option ([#21](https://github.com/rohal12/twee-ts/issues/21))
+  - `"tweego"` (default): NFKD normalize, divide character count by 5 (matches Tweego output)
+  - `"whitespace"`: standard whitespace-based word count after stripping comments, macros, links, and HTML tags
+- `--word-count-method` CLI flag
+- `wordCountMethod` config file option
+- `WordCountMethod` type exported from the public API
+- JSON Schema section in the configuration docs explaining `$schema` usage and SchemaStore integration
+
 ## [1.10.0] - 2026-03-06
 
 ### Added

--- a/bin/twee-ts.ts
+++ b/bin/twee-ts.ts
@@ -16,7 +16,7 @@ import {
   clearCachedFormats,
   getCacheSize,
 } from '../src/remote-formats.js';
-import type { TweeTsConfig, OutputMode } from '../src/types.js';
+import type { TweeTsConfig, OutputMode, WordCountMethod } from '../src/types.js';
 
 import { VERSION } from '../src/version.js';
 
@@ -50,6 +50,7 @@ const { values, positionals } = parseArgs({
     'no-remote': { type: 'boolean' },
     'tag-alias': { type: 'string', multiple: true },
     'source-info': { type: 'boolean' },
+    'word-count-method': { type: 'string' },
     config: { type: 'string', short: 'c' },
     'no-config': { type: 'boolean' },
   },
@@ -121,6 +122,18 @@ async function main(): Promise<void> {
     }
   }
 
+  // Word count method: CLI flag > config > default
+  const VALID_WORD_COUNT_METHODS: WordCountMethod[] = ['tweego', 'whitespace'];
+  const wordCountMethod: WordCountMethod | undefined = (() => {
+    const raw = values['word-count-method'] ?? config?.wordCountMethod;
+    if (raw === undefined) return undefined;
+    if (!VALID_WORD_COUNT_METHODS.includes(raw as WordCountMethod)) {
+      console.error(`Error: Invalid --word-count-method "${raw}". Expected: ${VALID_WORD_COUNT_METHODS.join(', ')}`);
+      process.exit(1);
+    }
+    return raw as WordCountMethod;
+  })();
+
   // Lint mode: compile + inspect, no output
   if (values.lint) {
     const lintResult = await lint({
@@ -138,6 +151,7 @@ async function main(): Promise<void> {
       noRemote: values['no-remote'] ?? config?.noRemote ?? false,
       tagAliases,
       sourceInfo: values['source-info'] ?? config?.sourceInfo ?? false,
+      wordCountMethod,
     });
     console.log(formatLintReport(lintResult));
     const hasErrors = lintResult.brokenLinks.length > 0 || lintResult.diagnostics.some((d) => d.level === 'error');
@@ -161,6 +175,7 @@ async function main(): Promise<void> {
     noRemote: values['no-remote'] ?? config?.noRemote ?? false,
     tagAliases,
     sourceInfo: values['source-info'] ?? config?.sourceInfo ?? false,
+    wordCountMethod,
   };
 
   const outFile = values.output ?? config?.output ?? '-';
@@ -362,6 +377,7 @@ Options:
   --format-url <url>        Direct format.js URL (repeatable)
   --tag-alias <alias=target> Map a tag to a special tag (repeatable)
   --source-info             Emit source file/line as data- attributes on passages
+  --word-count-method <m>   Word counting method: tweego (default), whitespace
   --no-remote               Disable remote format fetching
   -c, --config <file>       Config file path (default: ${CONFIG_FILENAME})
   --no-config               Skip config file loading

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,20 @@
 
 twee-ts automatically loads `twee-ts.config.json` from the current working directory. Use `-c <file>` to specify a different path, or `--no-config` to skip loading entirely.
 
+## JSON Schema
+
+The config file has a [JSON Schema](https://json-schema.org/) that provides autocompletion, validation, and inline documentation in editors like VS Code. Add a `$schema` key to enable it:
+
+```json
+{
+  "$schema": "https://unpkg.com/@rohal12/twee-ts/schemas/twee-ts.config.schema.json",
+  "sources": ["src/"],
+  "output": "story.html"
+}
+```
+
+The schema is also submitted to [SchemaStore](https://www.schemastore.org/), so editors that use SchemaStore will automatically associate `twee-ts.config.json` files with the schema — no `$schema` key needed.
+
 ## Minimal Config
 
 ```json
@@ -35,7 +49,8 @@ Every key with its default value:
   "testMode": false,
   "noRemote": false,
   "tagAliases": {},
-  "sourceInfo": false
+  "sourceInfo": false,
+  "wordCountMethod": "tweego"
 }
 ```
 
@@ -62,13 +77,14 @@ Every key with its default value:
 
 ### Compilation
 
-| Key            | Type      | Default   | Description                                                       |
-| -------------- | --------- | --------- | ----------------------------------------------------------------- |
-| `startPassage` | `string`  | `"Start"` | Name of the starting passage.                                     |
-| `trim`         | `boolean` | `true`    | Trim leading and trailing whitespace from passage content.        |
-| `twee2Compat`  | `boolean` | `false`   | Enable Twee2 syntax compatibility mode.                           |
-| `testMode`     | `boolean` | `false`   | Enable test/debug mode (sets the `debug` option in story data).   |
-| `sourceInfo`   | `boolean` | `false`   | Embed source file/line as `data-` attributes on passage elements. |
+| Key               | Type      | Default    | Description                                                                                    |
+| ----------------- | --------- | ---------- | ---------------------------------------------------------------------------------------------- |
+| `startPassage`    | `string`  | `"Start"`  | Name of the starting passage.                                                                  |
+| `trim`            | `boolean` | `true`     | Trim leading and trailing whitespace from passage content.                                     |
+| `twee2Compat`     | `boolean` | `false`    | Enable Twee2 syntax compatibility mode.                                                        |
+| `testMode`        | `boolean` | `false`    | Enable test/debug mode (sets the `debug` option in story data).                                |
+| `sourceInfo`      | `boolean` | `false`    | Embed source file/line as `data-` attributes on passage elements.                              |
+| `wordCountMethod` | `string`  | `"tweego"` | Word counting: `"tweego"` (chars / 5, matches Tweego) or `"whitespace"` (standard word count). |
 
 ### Head Injection
 

--- a/schemas/twee-ts.config.schema.json
+++ b/schemas/twee-ts.config.schema.json
@@ -92,6 +92,12 @@
       "type": "boolean",
       "default": false,
       "description": "Emit source file and line as data- attributes on passage elements."
+    },
+    "wordCountMethod": {
+      "type": "string",
+      "enum": ["tweego", "whitespace"],
+      "default": "tweego",
+      "description": "Word counting method. 'tweego': NFKD normalize, divide chars by 5 (matches Tweego). 'whitespace': split on whitespace after stripping comments and markup."
     }
   }
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -255,7 +255,7 @@ async function buildOutput(
 
   // Compute stats
   const stats: CompileStats = {
-    ...getStoryStats(story),
+    ...getStoryStats(story, options.wordCountMethod),
     files: [...processedFiles],
   };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,11 +3,12 @@
  */
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import type { TweeTsConfig, OutputMode } from './types.js';
+import type { TweeTsConfig, OutputMode, WordCountMethod } from './types.js';
 
 export const CONFIG_FILENAME = 'twee-ts.config.json';
 
 const VALID_OUTPUT_MODES: OutputMode[] = ['html', 'twee3', 'twee1', 'twine2-archive', 'twine1-archive', 'json'];
+const VALID_WORD_COUNT_METHODS: WordCountMethod[] = ['tweego', 'whitespace'];
 
 /** Load a config file from the given directory (default: cwd). Returns null if not found. */
 export function loadConfig(dir?: string): TweeTsConfig | null {
@@ -116,6 +117,16 @@ export function validateConfig(data: unknown): string[] {
   if ('outputMode' in obj) {
     if (typeof obj['outputMode'] !== 'string' || !VALID_OUTPUT_MODES.includes(obj['outputMode'] as OutputMode)) {
       errors.push(`"outputMode" must be one of: ${VALID_OUTPUT_MODES.join(', ')}.`);
+    }
+  }
+
+  // WordCountMethod validation
+  if ('wordCountMethod' in obj) {
+    if (
+      typeof obj['wordCountMethod'] !== 'string' ||
+      !VALID_WORD_COUNT_METHODS.includes(obj['wordCountMethod'] as WordCountMethod)
+    ) {
+      errors.push(`"wordCountMethod" must be one of: ${VALID_WORD_COUNT_METHODS.join(', ')}.`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export type {
   SourceLocation,
   TweeTsConfig,
   FileCacheEntry,
+  WordCountMethod,
 } from './types.js';
 export type { CachedFormatEntry } from './remote-formats.js';
 export type { StoryMap, BrokenLink } from './inspect.js';

--- a/src/passage.ts
+++ b/src/passage.ts
@@ -2,7 +2,7 @@
  * Passage helpers and output methods.
  * Ported from passage.go / passagedata.go.
  */
-import type { Passage, PassageMetadata, OutputMode } from './types.js';
+import type { Passage, PassageMetadata, OutputMode, WordCountMethod } from './types.js';
 import { attrEscape, fullAttrEscape, htmlEscape, tiddlerEscape, tweeEscape, rot13, commentSanitize } from './escape.js';
 
 // Info passages contain structural data, metadata, and code rather than story content.
@@ -166,19 +166,41 @@ export function passageToTiddler(p: Passage, pid: number, obfuscateRot13 = false
 }
 
 /**
- * Count words in a passage using the Tweego method:
- * Strip newlines, strip comments, count NFKD-normalized characters, divide by 5.
+ * Count words in a passage.
+ *
+ * - `'tweego'` (default): Strip newlines, strip comments, count NFKD-normalized characters, divide by 5.
+ * - `'whitespace'`: Strip comments and markup, split on whitespace, count tokens.
  */
-export function countWords(p: Passage): number {
-  let text = p.text;
-  text = text.replace(/\n/g, '');
-  text = text.replace(/(?:\/%.+?%\/|\/\*.+?\*\/|<!--.+?-->)/gs, '');
-  // Normalize to NFKD and count characters
-  const normalized = text.normalize('NFKD');
-  const count = [...normalized].length;
-  if (count === 0) return 0;
-  const words = Math.floor(count / 5);
-  return count % 5 > 0 ? words + 1 : words;
+export function countWords(p: Passage, method: WordCountMethod = 'tweego'): number {
+  switch (method) {
+    case 'tweego': {
+      let text = p.text;
+      text = text.replace(/\n/g, '');
+      text = text.replace(/(?:\/%.+?%\/|\/\*.+?\*\/|<!--.+?-->)/gs, '');
+      const normalized = text.normalize('NFKD');
+      const count = [...normalized].length;
+      if (count === 0) return 0;
+      const words = Math.floor(count / 5);
+      return count % 5 > 0 ? words + 1 : words;
+    }
+    case 'whitespace': {
+      let text = p.text;
+      // Strip comments
+      text = text.replace(/(?:\/%.+?%\/|\/\*.+?\*\/|<!--.+?-->)/gs, '');
+      // Strip Twine macros <<...>>
+      text = text.replace(/<<[^>]*>>/g, '');
+      // Strip Twine links [[...]] — keep display text
+      text = text.replace(/\[\[([^\]|]*?)(?:\|[^\]]*?)?\]\]/g, '$1');
+      // Strip HTML tags
+      text = text.replace(/<[^>]+>/g, '');
+      const tokens = text.split(/\s+/).filter((t) => t.length > 0);
+      return tokens.length;
+    }
+    default: {
+      const _exhaustive: never = method;
+      throw new Error(`Unhandled word count method: ${_exhaustive as string}`);
+    }
+  }
 }
 
 /**

--- a/src/story.ts
+++ b/src/story.ts
@@ -2,7 +2,7 @@
  * Story model + StoryData JSON marshal/unmarshal.
  * Ported from story.go + storydata.go.
  */
-import type { Story, Passage, Diagnostic } from './types.js';
+import type { Story, Passage, Diagnostic, WordCountMethod } from './types.js';
 import { validateIFID } from './ifid.js';
 import { isStoryPassage, countWords } from './passage.js';
 
@@ -271,13 +271,16 @@ export function storyAdd(story: Story, p: Passage, diagnostics: Diagnostic[]): v
 }
 
 /** Get story passage count and word count stats. */
-export function getStoryStats(story: Story): { passages: number; storyPassages: number; words: number } {
+export function getStoryStats(
+  story: Story,
+  wordCountMethod: WordCountMethod = 'tweego',
+): { passages: number; storyPassages: number; words: number } {
   let storyPassages = 0;
   let words = 0;
   for (const p of story.passages) {
     if (isStoryPassage(p)) {
       storyPassages++;
-      words += countWords(p);
+      words += countWords(p, wordCountMethod);
     }
   }
   return { passages: story.passages.length, storyPassages, words };

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,10 @@
 
 export type OutputMode = 'html' | 'twee3' | 'twee1' | 'twine2-archive' | 'twine1-archive' | 'json';
 
+// --- Word count ---
+
+export type WordCountMethod = 'tweego' | 'whitespace';
+
 // --- Source input ---
 
 export type InlineSource = { filename: string; content: string | Buffer };
@@ -46,6 +50,8 @@ export interface CompileOptions {
   tagAliases?: Record<string, string>;
   /** Emit source file and line as data- attributes on passage elements. Default: false. */
   sourceInfo?: boolean;
+  /** Word counting method. Default: 'tweego'. */
+  wordCountMethod?: WordCountMethod;
 }
 
 export interface CompileToFileOptions extends CompileOptions {
@@ -225,4 +231,5 @@ export interface TweeTsConfig {
   noRemote?: boolean;
   tagAliases?: Record<string, string>;
   sourceInfo?: boolean;
+  wordCountMethod?: WordCountMethod;
 }

--- a/test/passage.test.ts
+++ b/test/passage.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { applyTagAliases } from '../src/passage.js';
+import { applyTagAliases, countWords } from '../src/passage.js';
 import type { Passage } from '../src/types.js';
 
-function mkPassage(name: string, tags: string[]): Passage {
-  return { name, tags: [...tags], text: '' };
+function mkPassage(name: string, tags: string[], text = ''): Passage {
+  return { name, tags: [...tags], text };
 }
 
 describe('applyTagAliases', () => {
@@ -58,5 +58,83 @@ describe('applyTagAliases', () => {
     const passages = [mkPassage('A', [])];
     const result = applyTagAliases(passages, { library: 'script' });
     expect(result[0].tags).toEqual([]);
+  });
+});
+
+describe('countWords', () => {
+  describe('tweego method (default)', () => {
+    it('counts characters divided by 5', () => {
+      const p = mkPassage('A', [], 'Hello world');
+      // "Hello world" with newlines stripped = 11 chars → ceil(11/5) = 3
+      expect(countWords(p)).toBe(3);
+      expect(countWords(p, 'tweego')).toBe(3);
+    });
+
+    it('returns 0 for empty text', () => {
+      expect(countWords(mkPassage('A', [], ''))).toBe(0);
+    });
+
+    it('strips comments', () => {
+      const p = mkPassage('A', [], 'Hello/* comment */world');
+      // "Helloworld" = 10 chars → 10/5 = 2
+      expect(countWords(p, 'tweego')).toBe(2);
+    });
+
+    it('strips newlines before counting', () => {
+      const p = mkPassage('A', [], 'Hello\nworld');
+      // "Helloworld" = 10 chars → 10/5 = 2
+      expect(countWords(p, 'tweego')).toBe(2);
+    });
+  });
+
+  describe('whitespace method', () => {
+    it('counts words split by whitespace', () => {
+      const p = mkPassage('A', [], 'Hello world foo');
+      expect(countWords(p, 'whitespace')).toBe(3);
+    });
+
+    it('returns 0 for empty text', () => {
+      expect(countWords(mkPassage('A', [], ''), 'whitespace')).toBe(0);
+    });
+
+    it('strips comments', () => {
+      const p = mkPassage('A', [], 'Hello /* comment */ world');
+      expect(countWords(p, 'whitespace')).toBe(2);
+    });
+
+    it('strips HTML comments', () => {
+      const p = mkPassage('A', [], 'Hello <!-- comment --> world');
+      expect(countWords(p, 'whitespace')).toBe(2);
+    });
+
+    it('strips Twine macros', () => {
+      const p = mkPassage('A', [], 'Hello <<if $x>> world <<endif>>');
+      expect(countWords(p, 'whitespace')).toBe(2);
+    });
+
+    it('strips HTML tags', () => {
+      const p = mkPassage('A', [], '<b>Hello</b> <em>world</em>');
+      expect(countWords(p, 'whitespace')).toBe(2);
+    });
+
+    it('keeps display text from links', () => {
+      const p = mkPassage('A', [], 'Go to [[the garden|Garden]]');
+      expect(countWords(p, 'whitespace')).toBe(4); // "Go to the garden"
+    });
+
+    it('keeps text from simple links', () => {
+      const p = mkPassage('A', [], 'Visit [[Garden]]');
+      expect(countWords(p, 'whitespace')).toBe(2); // "Visit Garden"
+    });
+
+    it('handles SugarCube comments', () => {
+      const p = mkPassage('A', [], 'Hello /% inline comment %/ world');
+      expect(countWords(p, 'whitespace')).toBe(2);
+    });
+
+    it('handles multiple whitespace', () => {
+      const p = mkPassage('A', [], '  Hello   world  \n  foo  ');
+      expect(countWords(p, 'whitespace')).toBe(3);
+    });
   });
 });


### PR DESCRIPTION
release-npm

## Summary
- Configurable word counting method via `wordCountMethod` option ([#21](https://github.com/rohal12/twee-ts/issues/21))
  - `"tweego"` (default): chars / 5, matches Tweego
  - `"whitespace"`: standard word count after stripping comments, macros, links, and HTML
- `--word-count-method` CLI flag and config file support
- `WordCountMethod` type exported from the public API
- JSON Schema section added to configuration docs

## Checklist
- [x] Tests pass (`pnpm test`) — 1192 passing
- [x] Type check passes (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm run build`)
- [x] Formatting clean (`pnpm run format:check`)
- [x] CHANGELOG.md updated with v1.11.0

## Release
Merging this PR will trigger `release-npm-action` to publish v1.11.0 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)