### PR TITLE
release: v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-03-06
+
+### Added
+
+- HTML decompiler: parse compiled Twine 2 and Twine 1 HTML files back into a `Story` model ([#18](https://github.com/rohal12/twee-ts/issues/18))
+  - Twine 2: parses `<tw-storydata>`, `<tw-passagedata>`, `<style>`, `<script>`, and `<tw-tag>` elements
+  - Twine 1: parses `<div id="store-area">` / `<div id="storeArea">` with `<div tiddler="...">` children, including tiddler unescape
+  - Resolves start passage from `startnode` pid, preserves passage metadata (position, size, tags)
+- `decompileHTML()` and `DecompileResult` type exported from the public API
+- `.htm` and `.html` files now supported as compile inputs — enables `twee-ts -d story.html -o story.twee` round-trip workflow
+- `htmlparser2` bundled as a dev dependency (zero runtime deps maintained via tsup bundling)
+
 ## [1.11.0] - 2026-03-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@types/node": "^25.3.3",
     "@vitest/coverage-v8": "^4.0.18",
+    "htmlparser2": "^10.1.0",
     "prettier": "^3.8.1",
     "tsup": "^8.4.0",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@25.3.5)(tsx@4.21.0))
+      htmlparser2:
+        specifier: ^10.1.0
+        version: 10.1.0
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -875,8 +878,25 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -946,6 +966,9 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
@@ -2105,7 +2128,27 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   emoji-regex-xs@1.0.0: {}
+
+  entities@4.5.0: {}
 
   entities@7.0.1: {}
 
@@ -2220,6 +2263,13 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   is-what@5.5.0: {}
 

--- a/src/html-parser.ts
+++ b/src/html-parser.ts
@@ -1,0 +1,201 @@
+/**
+ * Twine HTML decompiler: parse compiled Twine 2 or Twine 1 HTML back into a Story model.
+ * Ported from storyload.go:loadHTML().
+ */
+import { parseDocument } from 'htmlparser2';
+import type { Passage, PassageMetadata, Diagnostic } from './types.js';
+import { createStory, storyAdd, storyPrepend, marshalStoryData } from './story.js';
+import { tiddlerUnescape } from './escape.js';
+
+export interface DecompileResult {
+  story: import('./types.js').Story;
+  diagnostics: Diagnostic[];
+}
+
+// Structural types matching domhandler's API (avoids direct import of domhandler).
+interface HtmlNode {
+  type: string;
+  name?: string;
+  attribs?: Record<string, string>;
+  children?: HtmlNode[];
+  data?: string;
+}
+
+/**
+ * Parse a Twine 2 or Twine 1 compiled HTML file back into a Story model.
+ */
+export function decompileHTML(html: string): DecompileResult {
+  const diagnostics: Diagnostic[] = [];
+  const story = createStory();
+
+  const doc = parseDocument(html) as unknown as HtmlNode;
+
+  // Try Twine 2 first (<tw-storydata>), then Twine 1 (<div id="store-area"> or <div id="storeArea">).
+  const twine2Data = findElement(doc, 'tw-storydata');
+  if (twine2Data) {
+    decompileTwine2(twine2Data, story, diagnostics);
+    return { story, diagnostics };
+  }
+
+  const twine1Data = findElementByIdPattern(doc, /^store(?:-a|A)rea$/);
+  if (twine1Data) {
+    decompileTwine1(twine1Data, story, diagnostics);
+    return { story, diagnostics };
+  }
+
+  diagnostics.push({ level: 'error', message: 'Malformed HTML source; story data not found.' });
+  return { story, diagnostics };
+}
+
+function decompileTwine2(storyData: HtmlNode, story: import('./types.js').Story, diagnostics: Diagnostic[]): void {
+  // Parse tw-storydata attributes.
+  let startnode = 0;
+  const attrs = storyData.attribs ?? {};
+
+  if (attrs['name']) story.name = attrs['name'];
+  if (attrs['startnode']) {
+    const parsed = parseInt(attrs['startnode'], 10);
+    if (Number.isNaN(parsed)) {
+      diagnostics.push({
+        level: 'warning',
+        message: `Cannot parse "tw-storydata" content attribute "startnode" as an integer; value "${attrs['startnode']}".`,
+      });
+    } else {
+      startnode = parsed;
+    }
+  }
+  if (attrs['ifid']) story.ifid = attrs['ifid'].toUpperCase();
+  if (attrs['zoom']) {
+    const parsed = parseFloat(attrs['zoom']);
+    if (Number.isNaN(parsed)) {
+      diagnostics.push({
+        level: 'warning',
+        message: `Cannot parse "tw-storydata" content attribute "zoom" as a float; value "${attrs['zoom']}".`,
+      });
+    } else {
+      story.twine2.zoom = parsed;
+    }
+  }
+  if (attrs['format']) story.twine2.format = attrs['format'];
+  if (attrs['format-version']) story.twine2.formatVersion = attrs['format-version'];
+  if (attrs['options']) {
+    for (const opt of attrs['options'].split(/\s+/).filter((s: string) => s.length > 0)) {
+      story.twine2.options.set(opt, true);
+    }
+  }
+
+  // Process child elements.
+  // htmlparser2 uses type 'style'/'script' for those elements instead of 'tag'.
+  for (const node of storyData.children ?? []) {
+    if (node.type !== 'tag' && node.type !== 'style' && node.type !== 'script') continue;
+
+    switch (node.name) {
+      case 'style':
+      case 'script': {
+        const text = getTextContent(node).trim();
+        if (text.length === 0) continue;
+        const name = node.name === 'style' ? 'Story Stylesheet' : 'Story JavaScript';
+        const tags = node.name === 'style' ? ['stylesheet'] : ['script'];
+        storyAdd(story, { name, tags, text }, diagnostics);
+        break;
+      }
+
+      case 'tw-tag': {
+        const tagAttrs = node.attribs ?? {};
+        const tagName = tagAttrs['name'] ?? '';
+        const tagColor = tagAttrs['color'] ?? '';
+        if (tagName) story.twine2.tagColors.set(tagName, tagColor);
+        break;
+      }
+
+      case 'tw-passagedata': {
+        let pid = 0;
+        const pAttrs = node.attribs ?? {};
+        const name = pAttrs['name'] ?? '';
+        const tags = pAttrs['tags'] ? pAttrs['tags'].split(/\s+/).filter((s: string) => s.length > 0) : [];
+        const metadata: PassageMetadata = {};
+
+        if (pAttrs['pid']) {
+          const parsed = parseInt(pAttrs['pid'], 10);
+          if (Number.isNaN(parsed)) {
+            diagnostics.push({
+              level: 'warning',
+              message: `Cannot parse "tw-passagedata" content attribute "pid" as an integer; value "${pAttrs['pid']}".`,
+            });
+          } else {
+            pid = parsed;
+          }
+        }
+
+        if (pAttrs['position']) metadata.position = pAttrs['position'];
+        if (pAttrs['size']) metadata.size = pAttrs['size'];
+
+        if (pid === startnode && pid !== 0) {
+          story.twine2.start = name;
+        }
+
+        const text = getTextContent(node).trim();
+        const passage: Passage = { name, tags, text };
+        if (metadata.position || metadata.size) {
+          passage.metadata = metadata;
+        }
+        storyAdd(story, passage, diagnostics);
+        break;
+      }
+    }
+  }
+
+  // Prepend StoryData passage with serialized metadata.
+  storyPrepend(story, { name: 'StoryData', tags: [], text: marshalStoryData(story) }, diagnostics);
+}
+
+function decompileTwine1(storeArea: HtmlNode, story: import('./types.js').Story, diagnostics: Diagnostic[]): void {
+  for (const node of storeArea.children ?? []) {
+    if (node.type !== 'tag' || node.name !== 'div') continue;
+    const nodeAttrs = node.attribs ?? {};
+    if (!('tiddler' in nodeAttrs)) continue;
+
+    const name = nodeAttrs['tiddler'] ?? '';
+    const tags = nodeAttrs['tags'] ? nodeAttrs['tags'].split(/\s+/).filter((s: string) => s.length > 0) : [];
+    const metadata: PassageMetadata = {};
+
+    if (nodeAttrs['twine-position']) metadata.position = nodeAttrs['twine-position'];
+
+    const rawContent = getTextContent(node);
+    const text = tiddlerUnescape(rawContent).trim();
+
+    const passage: Passage = { name, tags, text };
+    if (metadata.position) {
+      passage.metadata = metadata;
+    }
+    storyAdd(story, passage, diagnostics);
+  }
+}
+
+function findElement(node: HtmlNode, tagName: string): HtmlNode | undefined {
+  if (node.type === 'tag' && node.name === tagName) return node;
+  for (const child of node.children ?? []) {
+    const found = findElement(child, tagName);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function findElementByIdPattern(node: HtmlNode, idPattern: RegExp): HtmlNode | undefined {
+  if (node.type === 'tag' && node.attribs?.['id'] && idPattern.test(node.attribs['id'])) return node;
+  for (const child of node.children ?? []) {
+    const found = findElementByIdPattern(child, idPattern);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function getTextContent(el: HtmlNode): string {
+  let text = '';
+  for (const child of el.children ?? []) {
+    if (child.type === 'text' && child.data) {
+      text += child.data;
+    }
+  }
+  return text;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,9 @@ export { compile, compileIncremental, compileToFile, watch, TweeTsError } from '
 // Story inspection (for unit testing)
 export { storyInspect } from './inspect.js';
 
+// HTML decompiler
+export { decompileHTML } from './html-parser.js';
+
 // Lint
 export { lint, formatLintReport } from './lint.js';
 
@@ -61,5 +64,6 @@ export type {
   WordCountMethod,
 } from './types.js';
 export type { CachedFormatEntry } from './remote-formats.js';
+export type { DecompileResult } from './html-parser.js';
 export type { StoryMap, BrokenLink } from './inspect.js';
 export type { LintResult } from './lint.js';

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -8,6 +8,7 @@ import type { Story, Diagnostic, InlineSource, Passage, FileCacheEntry } from '.
 import { normalizedFileExt, mediaTypeFromFilename, mediaTypeFromExt, fontFormatHint } from './media-types.js';
 import { storyAdd, storyPrepend } from './story.js';
 import { parseTwee } from './parser.js';
+import { decompileHTML } from './html-parser.js';
 import { readUTF8, readBase64, baseNameWithoutExt } from './util.js';
 
 interface LoadOptions {
@@ -41,6 +42,10 @@ export function loadSources(
         case 'tw2':
         case 'twee2':
           loadTwee(story, filename, { ...opts, twee2Compat: true }, diagnostics);
+          break;
+        case 'htm':
+        case 'html':
+          loadHTML(story, filename, diagnostics);
           break;
         case 'css':
           loadTagged(story, 'stylesheet', filename, diagnostics);
@@ -184,6 +189,12 @@ function parseFontFile(filename: string): ParseResult {
   };
 }
 
+function parseHTMLFile(filename: string): ParseResult {
+  const source = readUTF8(filename);
+  const result = decompileHTML(source);
+  return { passages: result.story.passages, diagnostics: [...result.diagnostics] };
+}
+
 function parseFile(filename: string, opts: LoadOptions): ParseResult | undefined {
   const ext = normalizedFileExt(filename);
   switch (ext) {
@@ -193,6 +204,9 @@ function parseFile(filename: string, opts: LoadOptions): ParseResult | undefined
     case 'tw2':
     case 'twee2':
       return parseTweeFile(filename, { ...opts, twee2Compat: true });
+    case 'htm':
+    case 'html':
+      return parseHTMLFile(filename);
     case 'css':
       return parseTaggedFile('stylesheet', filename);
     case 'js':
@@ -230,6 +244,14 @@ function parseFile(filename: string, opts: LoadOptions): ParseResult | undefined
       return parseMediaFile('Twine.vtt', filename);
     default:
       return undefined;
+  }
+}
+
+function loadHTML(story: Story, filename: string, diagnostics: Diagnostic[]): void {
+  const result = parseHTMLFile(filename);
+  diagnostics.push(...result.diagnostics);
+  for (const p of result.passages) {
+    storyAdd(story, p, diagnostics);
   }
 }
 

--- a/src/media-types.ts
+++ b/src/media-types.ts
@@ -73,6 +73,8 @@ const KNOWN_EXTENSIONS = new Set([
   'twee',
   'tw2',
   'twee2',
+  'htm',
+  'html',
   'css',
   'js',
   'otf',

--- a/test/html-parser.test.ts
+++ b/test/html-parser.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import { decompileHTML } from '../src/html-parser.js';
+
+const MINIMAL_TWINE2_HTML = `<tw-storydata name="Test Story" startnode="1" creator="Twine" creator-version="2.0"
+  ifid="D674C58C-DEFA-4F70-B7A2-27742230C0FC" zoom="1"
+  format="SugarCube" format-version="2.37.3" options="" tags="" hidden>
+<style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">body { color: red; }</style>
+<script role="script" id="twine-user-script" type="text/twine-javascript">console.log("hi")</script>
+<tw-tag name="important" color="red"></tw-tag>
+<tw-passagedata pid="1" name="Start" tags="" position="100,100" size="100,100">Hello world</tw-passagedata>
+<tw-passagedata pid="2" name="Second" tags="tag1 tag2" position="200,100" size="100,100">Second passage</tw-passagedata>
+</tw-storydata>`;
+
+describe('decompileHTML', () => {
+  it('parses story metadata from tw-storydata', () => {
+    const { story, diagnostics } = decompileHTML(MINIMAL_TWINE2_HTML);
+    expect(diagnostics.filter((d) => d.level === 'error')).toHaveLength(0);
+    expect(story.name).toBe('Test Story');
+    expect(story.ifid).toBe('D674C58C-DEFA-4F70-B7A2-27742230C0FC');
+    expect(story.twine2.format).toBe('SugarCube');
+    expect(story.twine2.formatVersion).toBe('2.37.3');
+    expect(story.twine2.zoom).toBe(1);
+  });
+
+  it('parses passages from tw-passagedata', () => {
+    const { story } = decompileHTML(MINIMAL_TWINE2_HTML);
+    const start = story.passages.find((p) => p.name === 'Start');
+    expect(start).toBeDefined();
+    expect(start!.text).toBe('Hello world');
+    expect(start!.metadata?.position).toBe('100,100');
+    expect(start!.metadata?.size).toBe('100,100');
+  });
+
+  it('parses passage tags', () => {
+    const { story } = decompileHTML(MINIMAL_TWINE2_HTML);
+    const second = story.passages.find((p) => p.name === 'Second');
+    expect(second).toBeDefined();
+    expect(second!.tags).toEqual(['tag1', 'tag2']);
+  });
+
+  it('resolves start passage from startnode pid', () => {
+    const { story } = decompileHTML(MINIMAL_TWINE2_HTML);
+    expect(story.twine2.start).toBe('Start');
+  });
+
+  it('parses stylesheet from style element', () => {
+    const { story } = decompileHTML(MINIMAL_TWINE2_HTML);
+    const stylesheet = story.passages.find((p) => p.name === 'Story Stylesheet');
+    expect(stylesheet).toBeDefined();
+    expect(stylesheet!.tags).toContain('stylesheet');
+    expect(stylesheet!.text).toBe('body { color: red; }');
+  });
+
+  it('parses script from script element', () => {
+    const { story } = decompileHTML(MINIMAL_TWINE2_HTML);
+    const script = story.passages.find((p) => p.name === 'Story JavaScript');
+    expect(script).toBeDefined();
+    expect(script!.tags).toContain('script');
+    expect(script!.text).toBe('console.log("hi")');
+  });
+
+  it('parses tag colors from tw-tag elements', () => {
+    const { story } = decompileHTML(MINIMAL_TWINE2_HTML);
+    expect(story.twine2.tagColors.get('important')).toBe('red');
+  });
+
+  it('prepends StoryData passage', () => {
+    const { story } = decompileHTML(MINIMAL_TWINE2_HTML);
+    expect(story.passages[0]?.name).toBe('StoryData');
+    const data = JSON.parse(story.passages[0]!.text);
+    expect(data.ifid).toBe('D674C58C-DEFA-4F70-B7A2-27742230C0FC');
+    expect(data.format).toBe('SugarCube');
+  });
+
+  it('returns error diagnostic for missing tw-storydata', () => {
+    const { diagnostics } = decompileHTML('<html><body>no story here</body></html>');
+    expect(diagnostics.some((d) => d.level === 'error' && d.message.includes('story data not found'))).toBe(true);
+  });
+
+  it('handles empty stylesheet and script elements', () => {
+    const html = `<tw-storydata name="Empty" startnode="1" ifid="D674C58C-DEFA-4F70-B7A2-27742230C0FC" format="SugarCube" format-version="2.37.3" hidden>
+<style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style>
+<script role="script" id="twine-user-script" type="text/twine-javascript"></script>
+<tw-passagedata pid="1" name="Start" tags="" position="100,100" size="100,100">Hello</tw-passagedata>
+</tw-storydata>`;
+    const { story } = decompileHTML(html);
+    expect(story.passages.find((p) => p.name === 'Story Stylesheet')).toBeUndefined();
+    expect(story.passages.find((p) => p.name === 'Story JavaScript')).toBeUndefined();
+  });
+
+  it('decodes HTML entities in passage content', () => {
+    const html = `<tw-storydata name="Entities" startnode="1" ifid="D674C58C-DEFA-4F70-B7A2-27742230C0FC" format="SugarCube" format-version="2.37.3" hidden>
+<tw-passagedata pid="1" name="Start" tags="" position="100,100" size="100,100">&lt;b&gt;bold&lt;/b&gt; &amp; &quot;quoted&quot;</tw-passagedata>
+</tw-storydata>`;
+    const { story } = decompileHTML(html);
+    const start = story.passages.find((p) => p.name === 'Start');
+    expect(start!.text).toBe('<b>bold</b> & "quoted"');
+  });
+
+  it('decodes HTML entities in passage names', () => {
+    const html = `<tw-storydata name="Entities" startnode="1" ifid="D674C58C-DEFA-4F70-B7A2-27742230C0FC" format="SugarCube" format-version="2.37.3" hidden>
+<tw-passagedata pid="1" name="Foo &amp; Bar" tags="" position="100,100" size="100,100">Content</tw-passagedata>
+</tw-storydata>`;
+    const { story } = decompileHTML(html);
+    expect(story.passages.some((p) => p.name === 'Foo & Bar')).toBe(true);
+  });
+
+  it('parses options attribute', () => {
+    const html = `<tw-storydata name="Opts" startnode="1" ifid="D674C58C-DEFA-4F70-B7A2-27742230C0FC"
+      format="SugarCube" format-version="2.37.3" options="debug" hidden>
+<tw-passagedata pid="1" name="Start" tags="" position="100,100" size="100,100">Hello</tw-passagedata>
+</tw-storydata>`;
+    const { story } = decompileHTML(html);
+    expect(story.twine2.options.get('debug')).toBe(true);
+  });
+
+  it('handles full HTML document wrapping tw-storydata', () => {
+    const html = `<!DOCTYPE html>
+<html>
+<head><title>My Story</title></head>
+<body>
+${MINIMAL_TWINE2_HTML}
+</body>
+</html>`;
+    const { story, diagnostics } = decompileHTML(html);
+    expect(diagnostics.filter((d) => d.level === 'error')).toHaveLength(0);
+    expect(story.name).toBe('Test Story');
+    expect(story.passages.find((p) => p.name === 'Start')).toBeDefined();
+  });
+});
+
+const MINIMAL_TWINE1_HTML = `<div id="store-area" data-size="3" hidden>
+<div tiddler="Start" tags="" created="202301010000" modified="202301010000" modifier="twee" twine-position="100,100">Hello from Twine 1</div>
+<div tiddler="Second" tags="tag1 tag2" created="202301010000" modified="202301010000" modifier="twee" twine-position="200,100">Second passage</div>
+<div tiddler="StorySettings" tags="" created="202301010000" modified="202301010000" modifier="twee" twine-position="300,100">undo:off</div>
+</div>`;
+
+describe('decompileHTML — Twine 1', () => {
+  it('parses passages from tiddler divs', () => {
+    const { story, diagnostics } = decompileHTML(MINIMAL_TWINE1_HTML);
+    expect(diagnostics.filter((d) => d.level === 'error')).toHaveLength(0);
+    const start = story.passages.find((p) => p.name === 'Start');
+    expect(start).toBeDefined();
+    expect(start!.text).toBe('Hello from Twine 1');
+  });
+
+  it('parses passage tags', () => {
+    const { story } = decompileHTML(MINIMAL_TWINE1_HTML);
+    const second = story.passages.find((p) => p.name === 'Second');
+    expect(second).toBeDefined();
+    expect(second!.tags).toEqual(['tag1', 'tag2']);
+  });
+
+  it('parses twine-position as metadata', () => {
+    const { story } = decompileHTML(MINIMAL_TWINE1_HTML);
+    const start = story.passages.find((p) => p.name === 'Start');
+    expect(start!.metadata?.position).toBe('100,100');
+  });
+
+  it('unescapes tiddler content', () => {
+    const html = `<div id="store-area" hidden>
+<div tiddler="Escaped" tags="" twine-position="100,100">Line 1\\nLine 2\\tTabbed\\sBackslash</div>
+</div>`;
+    const { story } = decompileHTML(html);
+    const p = story.passages.find((p) => p.name === 'Escaped');
+    expect(p!.text).toBe('Line 1\nLine 2\tTabbed\\Backslash');
+  });
+
+  it('handles storeArea variant (camelCase id)', () => {
+    const html = `<div id="storeArea" hidden>
+<div tiddler="Start" tags="" twine-position="100,100">Hello</div>
+</div>`;
+    const { story, diagnostics } = decompileHTML(html);
+    expect(diagnostics.filter((d) => d.level === 'error')).toHaveLength(0);
+    expect(story.passages.find((p) => p.name === 'Start')).toBeDefined();
+  });
+
+  it('skips non-tiddler child divs', () => {
+    const html = `<div id="store-area" hidden>
+<div class="other">Not a tiddler</div>
+<div tiddler="Start" tags="" twine-position="100,100">Hello</div>
+</div>`;
+    const { story } = decompileHTML(html);
+    expect(story.passages).toHaveLength(1);
+    expect(story.passages[0]!.name).toBe('Start');
+  });
+
+  it('handles full HTML document wrapping store-area', () => {
+    const html = `<!DOCTYPE html>
+<html>
+<head><title>My Twine 1 Story</title></head>
+<body>
+${MINIMAL_TWINE1_HTML}
+</body>
+</html>`;
+    const { story, diagnostics } = decompileHTML(html);
+    expect(diagnostics.filter((d) => d.level === 'error')).toHaveLength(0);
+    expect(story.passages.find((p) => p.name === 'Start')).toBeDefined();
+  });
+
+  it('handles empty tiddler content', () => {
+    const html = `<div id="store-area" hidden>
+<div tiddler="Empty" tags="" twine-position="100,100"></div>
+</div>`;
+    const { story } = decompileHTML(html);
+    const p = story.passages.find((p) => p.name === 'Empty');
+    expect(p).toBeDefined();
+    expect(p!.text).toBe('');
+  });
+});


### PR DESCRIPTION
release-npm

## Summary
- HTML decompiler: parse compiled Twine 2 and Twine 1 HTML files back into a `Story` model (#18)
- `decompileHTML()` and `DecompileResult` type exported from the public API
- `.htm`/`.html` files now supported as compile inputs (enables `twee-ts -d story.html -o story.twee`)
- `htmlparser2` bundled via tsup (zero runtime deps maintained)

## Checklist
- [x] Tests pass (`pnpm test`) — 1214 tests
- [x] Type check passes (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm run build`)
- [x] Formatting clean (`pnpm run format:check`)
- [x] CHANGELOG.md updated with new version

## Release
Merging this PR will trigger `release-npm-action` to publish v1.12.0 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)