### PR TITLE
release: v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2026-03-06
+
+### Added
+
+- Branded `IFID` type for compile-time safety — prevents passing unvalidated strings where an IFID is expected ([#25](https://github.com/rohal12/twee-ts/issues/25))
+- `createIFID()` function to validate and brand an IFID string
+- `ReadonlyStory` and `ReadonlyPassage` types for immutable post-construction access ([#26](https://github.com/rohal12/twee-ts/issues/26))
+- `StoryBuilder` class that separates mutable construction from immutable consumption ([#8](https://github.com/rohal12/twee-ts/issues/8))
+- `Diagnostic` is now a discriminated union on `level`, with optional `fatal` field on error diagnostics ([#9](https://github.com/rohal12/twee-ts/issues/9))
+- `ItemType` converted from `const enum` to `const` object pattern for runtime access and `--isolatedModules` compatibility ([#11](https://github.com/rohal12/twee-ts/issues/11))
+
+### Changed
+
+- `CompileResult.story` now returns `ReadonlyStory` instead of `Story`
+- Output renderers (`toTwine2HTML`, `toTwine2Archive`, `toTwine1HTML`, `toTwee`) now accept `ReadonlyStory` and no longer take `diagnostics` parameter — they are pure transforms ([#12](https://github.com/rohal12/twee-ts/issues/12))
+- `ensureIFID()` moved from output phase to compilation phase in `buildOutput()` ([#12](https://github.com/rohal12/twee-ts/issues/12))
+- `storyInspect()` now accepts `ReadonlyStory`
+- Lexer `emit()` now has a comment block explaining the line-counting invariant ([#10](https://github.com/rohal12/twee-ts/issues/10))
+
 ## [1.12.0] - 2026-03-06
 
 ### Added

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -22,6 +22,7 @@ import { getFilenames, watchFilesystem } from './filesystem.js';
 import { discoverFormats, getFormatSearchDirs, getFormatIdByNameAndVersion } from './formats.js';
 import { loadSources, loadInlineSources, loadSourcesCached } from './loader.js';
 import { applyTagAliases, hasTag } from './passage.js';
+import { generateIFID } from './ifid.js';
 import { toTwine2HTML, toTwine2Archive } from './output-twine2.js';
 import { toTwine1HTML, toTwine1Archive } from './output-twine1.js';
 import { toTwee } from './output-twee.js';
@@ -195,6 +196,9 @@ async function buildOutput(
     story.twine2.options.set('debug', true);
   }
 
+  // Ensure IFID is set before output generation
+  ensureIFID(story, diagnostics);
+
   // Generate output
   let output: string;
 
@@ -205,7 +209,7 @@ async function buildOutput(
       break;
 
     case 'twine2-archive':
-      output = toTwine2Archive(story, startName, diagnostics, { sourceInfo });
+      output = toTwine2Archive(story, startName, { sourceInfo });
       break;
 
     case 'twine1-archive':
@@ -230,7 +234,7 @@ async function buildOutput(
       }
 
       if (format.isTwine2) {
-        output = toTwine2HTML(story, format, startName, diagnostics, { sourceInfo });
+        output = toTwine2HTML(story, format, startName, { sourceInfo });
       } else {
         if (story.name === '' && !storyHas(story, 'StoryTitle')) {
           diagnostics.push({
@@ -238,7 +242,7 @@ async function buildOutput(
             message: 'Special passage "StoryTitle" not found.',
           });
         }
-        output = toTwine1HTML(story, format, startName, diagnostics);
+        output = toTwine1HTML(story, format, startName);
       }
 
       // Inject modules and head file
@@ -260,6 +264,25 @@ async function buildOutput(
   };
 
   return { output, story, format, diagnostics, stats };
+}
+
+function ensureIFID(story: Story, diagnostics: Diagnostic[]): void {
+  if (story.ifid !== '') return;
+
+  if (story.legacyIFID !== '') {
+    story.ifid = story.legacyIFID;
+    diagnostics.push({
+      level: 'warning',
+      message: 'Story IFID not found; reusing "ifid" entry from the "StorySettings" special passage.',
+    });
+  } else {
+    const ifid = generateIFID();
+    story.ifid = ifid;
+    diagnostics.push({
+      level: 'error',
+      message: `Story IFID not found. Add an IFID to your story: {"ifid":"${ifid}"}`,
+    });
+  }
 }
 
 /**

--- a/src/html-parser.ts
+++ b/src/html-parser.ts
@@ -3,7 +3,7 @@
  * Ported from storyload.go:loadHTML().
  */
 import { parseDocument } from 'htmlparser2';
-import type { Passage, PassageMetadata, Diagnostic } from './types.js';
+import type { Passage, PassageMetadata, Diagnostic, IFID } from './types.js';
 import { createStory, storyAdd, storyPrepend, marshalStoryData } from './story.js';
 import { tiddlerUnescape } from './escape.js';
 
@@ -64,7 +64,7 @@ function decompileTwine2(storyData: HtmlNode, story: import('./types.js').Story,
       startnode = parsed;
     }
   }
-  if (attrs['ifid']) story.ifid = attrs['ifid'].toUpperCase();
+  if (attrs['ifid']) story.ifid = attrs['ifid'].toUpperCase() as IFID;
   if (attrs['zoom']) {
     const parsed = parseFloat(attrs['zoom']);
     if (Number.isNaN(parsed)) {

--- a/src/ifid.ts
+++ b/src/ifid.ts
@@ -3,10 +3,18 @@
  * Ported from ifid.go.
  */
 import { randomUUID } from 'node:crypto';
+import type { IFID } from './types.js';
 
 /** Generate a new IFID (UUID v4, uppercase). */
-export function generateIFID(): string {
-  return randomUUID().toUpperCase();
+export function generateIFID(): IFID {
+  return randomUUID().toUpperCase() as IFID;
+}
+
+/** Validate and brand an IFID string. Throws on invalid input. */
+export function createIFID(value: string): IFID {
+  const err = validateIFID(value);
+  if (err) throw new Error(`Invalid IFID: ${err}`);
+  return value.toUpperCase() as IFID;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { compile, compileIncremental, compileToFile, watch, TweeTsError } from '
 
 // Story inspection (for unit testing)
 export { storyInspect } from './inspect.js';
+export { StoryBuilder } from './story.js';
 
 // HTML decompiler
 export { decompileHTML } from './html-parser.js';
@@ -22,7 +23,7 @@ export { applyTagAliases } from './passage.js';
 export { TweeLexer, tweeLexer } from './lexer.js';
 export { parseTwee } from './parser.js';
 export { discoverFormats, getFormatSearchDirs, parseSemver, semverCompare, parseFormatJSON } from './formats.js';
-export { generateIFID, validateIFID } from './ifid.js';
+export { generateIFID, validateIFID, createIFID } from './ifid.js';
 
 // Config
 export { loadConfig, loadConfigFile, validateConfig, scaffoldConfig, CONFIG_FILENAME } from './config.js';
@@ -38,6 +39,9 @@ export {
   clearCachedFormats,
   getCacheSize,
 } from './remote-formats.js';
+
+// Runtime values
+export { ItemType } from './types.js';
 
 // Types
 export type {
@@ -55,7 +59,9 @@ export type {
   SourceInput,
   InlineSource,
   LexerItem,
-  ItemType,
+  IFID,
+  ReadonlyStory,
+  ReadonlyPassage,
   SFAIndex,
   SFAIndexEntry,
   SourceLocation,

--- a/src/inspect.ts
+++ b/src/inspect.ts
@@ -10,7 +10,7 @@
  *   expect(map.passages).toContain('Start');
  *   expect(map.brokenLinks).toHaveLength(0);
  */
-import type { Story } from './types.js';
+import type { ReadonlyStory } from './types.js';
 import { isInfoPassage, isStoryPassage } from './passage.js';
 
 export interface StoryMap {
@@ -115,7 +115,7 @@ function extractLinksFromText(text: string): string[] {
  * expect(map.deadEnds).not.toContain('Start');
  * ```
  */
-export function storyInspect(story: Story): StoryMap {
+export function storyInspect(story: ReadonlyStory): StoryMap {
   const allNames = new Set(story.passages.map((p) => p.name));
 
   const passages: string[] = [];

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -44,10 +44,15 @@ class LexerContext {
     }
   }
 
+  // Line-counting invariant: next() increments this.line for each newline during
+  // character-by-character scanning. However, Content items are produced by jumping
+  // this.pos directly (e.g. via indexOf) without calling next(), so those newlines
+  // haven't been counted yet. emit() re-counts newlines in [start, pos) for Content
+  // items to compensate. This is safe because this.start is reset to this.pos after
+  // every emit(), so no range is ever counted twice.
   emit(type: ItemType): void {
     const val = this.input.slice(this.start, this.pos);
     this.items.push({ type, line: this.line, pos: this.start, val });
-    // Content items may contain newlines that must be counted.
     if (type === ItemType.Content) {
       for (let i = this.start; i < this.pos; i++) {
         if (this.input.charCodeAt(i) === 0x0a) this.line++;

--- a/src/output-twee.ts
+++ b/src/output-twee.ts
@@ -2,10 +2,10 @@
  * Twee 3/1 decompile output.
  * Ported from storyout.go.
  */
-import type { Story, OutputMode } from './types.js';
+import type { ReadonlyStory, OutputMode } from './types.js';
 import { passageToTwee } from './passage.js';
 
-export function toTwee(story: Story, outMode: OutputMode): string {
+export function toTwee(story: ReadonlyStory, outMode: OutputMode): string {
   let data = '';
   for (const p of story.passages) {
     data += passageToTwee(p, outMode);

--- a/src/output-twine1.ts
+++ b/src/output-twine1.ts
@@ -4,7 +4,7 @@
  */
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import type { Story, StoryFormatInfo, Diagnostic } from './types.js';
+import type { ReadonlyStory, StoryFormatInfo } from './types.js';
 import { hasTag, passageToTiddler } from './passage.js';
 import { readFormatSource } from './formats.js';
 import { jsStringEscape, htmlCommentSanitize } from './escape.js';
@@ -12,17 +12,12 @@ import { VERSION } from './version.js';
 
 const CREATOR_NAME = 'twee-ts';
 
-export function toTwine1Archive(story: Story, _startName: string): string {
+export function toTwine1Archive(story: ReadonlyStory, _startName: string): string {
   const { data, count } = getTwine1PassageChunk(story);
   return `<div id="storeArea" data-size="${count}">${data}</div>\n`;
 }
 
-export function toTwine1HTML(
-  story: Story,
-  format: StoryFormatInfo,
-  startName: string,
-  _diagnostics: Diagnostic[],
-): string {
+export function toTwine1HTML(story: ReadonlyStory, format: StoryFormatInfo, startName: string): string {
   const formatDir = dirname(format.filename);
   const parentDir = dirname(formatDir);
   let template = readFormatSource(format);
@@ -74,7 +69,7 @@ export function toTwine1HTML(
   return template;
 }
 
-function getTwine1PassageChunk(story: Story): { data: string; count: number } {
+function getTwine1PassageChunk(story: ReadonlyStory): { data: string; count: number } {
   const obfuscateRot13 = story.twine1.settings.get('obfuscate') === 'rot13';
   let data = '';
   let count = 0;

--- a/src/output-twine2.ts
+++ b/src/output-twine2.ts
@@ -2,29 +2,26 @@
  * Twine 2 HTML and archive output.
  * Ported from storyout.go.
  */
-import type { Story, StoryFormatInfo, Diagnostic } from './types.js';
+import type { ReadonlyStory, ReadonlyPassage, StoryFormatInfo } from './types.js';
 import { attrEscape, htmlEscape, commentSanitize, htmlCommentSanitize } from './escape.js';
 import { passageToPassagedata, hasTag, hasAnyTag } from './passage.js';
-import { generateIFID } from './ifid.js';
 import { readFormatSource } from './formats.js';
 import { VERSION } from './version.js';
 
 const CREATOR_NAME = 'Twee-ts';
 
 export function toTwine2Archive(
-  story: Story,
+  story: ReadonlyStory,
   startName: string,
-  diagnostics: Diagnostic[],
   options?: { readonly sourceInfo?: boolean },
 ): string {
-  return getTwine2DataChunk(story, startName, diagnostics, options) + '\n';
+  return getTwine2DataChunk(story, startName, options) + '\n';
 }
 
 export function toTwine2HTML(
-  story: Story,
+  story: ReadonlyStory,
   format: StoryFormatInfo,
   startName: string,
-  diagnostics: Diagnostic[],
   options?: { readonly sourceInfo?: boolean },
 ): string {
   let template = readFormatSource(format);
@@ -33,28 +30,24 @@ export function toTwine2HTML(
     template = template.replaceAll('{{STORY_NAME}}', htmlEscape(story.name));
   }
   if (template.includes('{{STORY_DATA}}')) {
-    template = template.replace('{{STORY_DATA}}', getTwine2DataChunk(story, startName, diagnostics, options));
+    template = template.replace('{{STORY_DATA}}', getTwine2DataChunk(story, startName, options));
   }
 
   return template;
 }
 
 function getTwine2DataChunk(
-  story: Story,
+  story: ReadonlyStory,
   startName: string,
-  diagnostics: Diagnostic[],
   options?: { readonly sourceInfo?: boolean },
 ): string {
-  // Check IFID status and generate if missing.
-  ensureIFID(story, diagnostics);
-
   const parts: string[] = [];
   let startID = '';
   let pid = 0;
 
   // Gather script and stylesheet passages.
-  const scripts: typeof story.passages = [];
-  const stylesheets: typeof story.passages = [];
+  const scripts: ReadonlyPassage[] = [];
+  const stylesheets: ReadonlyPassage[] = [];
   for (const p of story.passages) {
     if (hasTag(p, 'Twine.private')) continue;
     if (hasTag(p, 'script')) scripts.push(p);
@@ -138,23 +131,4 @@ function getTwine2DataChunk(
     `options="${attrEscape(optionsStr)}" tags="${attrEscape(story.twine2.tags)}" hidden>`;
 
   return wrapper + parts.join('') + '</tw-storydata>';
-}
-
-function ensureIFID(story: Story, diagnostics: Diagnostic[]): void {
-  if (story.ifid !== '') return;
-
-  if (story.legacyIFID !== '') {
-    story.ifid = story.legacyIFID;
-    diagnostics.push({
-      level: 'warning',
-      message: 'Story IFID not found; reusing "ifid" entry from the "StorySettings" special passage.',
-    });
-  } else {
-    const ifid = generateIFID();
-    story.ifid = ifid;
-    diagnostics.push({
-      level: 'error',
-      message: `Story IFID not found. Add an IFID to your story: {"ifid":"${ifid}"}`,
-    });
-  }
 }

--- a/src/story.ts
+++ b/src/story.ts
@@ -2,7 +2,7 @@
  * Story model + StoryData JSON marshal/unmarshal.
  * Ported from story.go + storydata.go.
  */
-import type { Story, Passage, Diagnostic, WordCountMethod } from './types.js';
+import type { Story, ReadonlyStory, Passage, Diagnostic, WordCountMethod, IFID } from './types.js';
 import { validateIFID } from './ifid.js';
 import { isStoryPassage, countWords } from './passage.js';
 
@@ -26,9 +26,9 @@ function getIndex(story: Story): Map<string, number> {
 export function createStory(): Story {
   const story: Story = {
     name: '',
-    ifid: '',
+    ifid: '' as IFID,
     passages: [],
-    legacyIFID: '',
+    legacyIFID: '' as IFID,
     twine1: { settings: new Map() },
     twine2: {
       format: '',
@@ -141,7 +141,7 @@ export function unmarshalStoryData(story: Story, json: string): string | null {
   }
   const data = raw as StoryDataJSON;
 
-  if (typeof data.ifid === 'string' && data.ifid) story.ifid = data.ifid.toUpperCase();
+  if (typeof data.ifid === 'string' && data.ifid) story.ifid = data.ifid.toUpperCase() as IFID;
   if (typeof data.format === 'string' && data.format) story.twine2.format = data.format;
   if (typeof data['format-version'] === 'string' && data['format-version'])
     story.twine2.formatVersion = data['format-version'];
@@ -190,7 +190,7 @@ export function unmarshalStorySettings(story: Story, text: string, diagnostics: 
       case 'ifid': {
         const err = validateIFID(val);
         if (err === null) {
-          story.legacyIFID = val.toUpperCase();
+          story.legacyIFID = val.toUpperCase() as IFID;
         }
         obsolete.push('"ifid"');
         continue;
@@ -284,4 +284,33 @@ export function getStoryStats(
     }
   }
   return { passages: story.passages.length, storyPassages, words };
+}
+
+/**
+ * Builder that separates the mutable construction phase from the immutable consumption phase.
+ * During construction, the internal `Story` is mutable via `add()` and direct access.
+ * After `build()`, the story is returned as `ReadonlyStory`.
+ */
+export class StoryBuilder {
+  /** The mutable story, accessible during construction for loader functions. */
+  readonly story: Story;
+
+  constructor() {
+    this.story = createStory();
+  }
+
+  /** Add a passage, handling special passages (StoryData, StoryTitle, etc.). */
+  add(passage: Passage, diagnostics: Diagnostic[]): void {
+    storyAdd(this.story, passage, diagnostics);
+  }
+
+  /** Check if a passage name exists. */
+  has(name: string): boolean {
+    return storyHas(this.story, name);
+  }
+
+  /** Finalize and return the story as read-only. */
+  build(): ReadonlyStory {
+    return this.story;
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,18 +68,15 @@ export interface WatchOptions extends CompileToFileOptions {
 
 // --- Compile result ---
 
-export interface Diagnostic {
-  level: 'warning' | 'error';
-  message: string;
-  file?: string;
-  line?: number;
-}
+export type Diagnostic =
+  | { level: 'warning'; message: string; file?: string; line?: number }
+  | { level: 'error'; message: string; file?: string; line?: number; fatal?: boolean };
 
 export interface CompileResult {
   /** The compiled output string (HTML, Twee, JSON, etc.). */
   output: string;
-  /** The parsed story model. */
-  story: Story;
+  /** The parsed story model (read-only after compilation). */
+  story: ReadonlyStory;
   /** The format used for compilation (undefined for non-HTML modes). */
   format?: StoryFormatInfo;
   /** Collected diagnostics. */
@@ -116,6 +113,10 @@ export interface Passage {
   source?: SourceLocation;
 }
 
+// --- Branded types ---
+
+export type IFID = string & { readonly __brand: 'IFID' };
+
 // --- Story ---
 
 export interface Twine1Metadata {
@@ -134,12 +135,29 @@ export interface Twine2Metadata {
 
 export interface Story {
   name: string;
-  ifid: string;
+  ifid: IFID;
   passages: Passage[];
-  legacyIFID: string;
+  legacyIFID: IFID;
   twine1: Twine1Metadata;
   twine2: Twine2Metadata;
 }
+
+// --- Readonly story (post-construction) ---
+
+export type ReadonlyPassage = Readonly<Passage> & {
+  readonly tags: readonly string[];
+};
+
+export type ReadonlyStory = Readonly<Omit<Story, 'passages' | 'twine1' | 'twine2'>> & {
+  readonly passages: readonly ReadonlyPassage[];
+  readonly twine1: Readonly<Omit<Twine1Metadata, 'settings'>> & {
+    readonly settings: ReadonlyMap<string, string>;
+  };
+  readonly twine2: Readonly<Omit<Twine2Metadata, 'options' | 'tagColors'>> & {
+    readonly options: ReadonlyMap<string, boolean>;
+    readonly tagColors: ReadonlyMap<string, string>;
+  };
+};
 
 // --- Story format ---
 
@@ -171,15 +189,16 @@ export interface Twine2FormatJSON {
 
 // --- Lexer ---
 
-export const enum ItemType {
-  Error = 0,
-  EOF = 1,
-  Header = 2,
-  Name = 3,
-  Tags = 4,
-  Metadata = 5,
-  Content = 6,
-}
+export const ItemType = {
+  Error: 0,
+  EOF: 1,
+  Header: 2,
+  Name: 3,
+  Tags: 4,
+  Metadata: 5,
+  Content: 6,
+} as const;
+export type ItemType = (typeof ItemType)[keyof typeof ItemType];
 
 export interface LexerItem {
   type: ItemType;


### PR DESCRIPTION
release-npm

## Summary
- Branded `IFID` type with `createIFID()` for compile-time safety (#25)
- `ReadonlyStory` and `ReadonlyPassage` types for immutable post-construction access (#26)
- `StoryBuilder` class separating mutable construction from immutable consumption (#8)
- `Diagnostic` discriminated union with optional `fatal` on errors (#9)
- `ItemType` converted from `const enum` to `const` object pattern (#11)
- `ensureIFID` moved from output to compilation phase; output renderers are now pure transforms (#12)
- Lexer `emit()` line-counting invariant documented (#10)

## Checklist
- [x] Tests pass (`pnpm test`)
- [x] Type check passes (`pnpm run typecheck`)
- [x] Build succeeds (`pnpm run build`)
- [x] Formatting clean (`pnpm run format:check`)
- [x] CHANGELOG.md updated with new version

## Release
Merging this PR will trigger `release-npm-action` to publish v1.13.0 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)