### PR TITLE
release: v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-03-19
+
+### Fixed
+
+- `String.replace` `$&` corruption when inlining JS modules — `$&`, `` $` ``, `$'`, and `$<digits>` in module content were silently replaced by `String.replace()` special patterns, corrupting bundled JavaScript ([#46](https://github.com/rohal12/twee-ts/issues/46))
+- Same `String.replace` corruption in Twine 2 and Twine 1 HTML output renderers when story content contains replacement patterns
+
 ## [1.13.0] - 2026-03-06
 
 ### Added

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -90,7 +90,8 @@ export function modifyHead(html: string, modulePaths: string[], headFile?: strin
 
   if (parts.length > 0) {
     parts.push('</head>');
-    return html.replace('</head>', parts.join('\n'));
+    const replacement = parts.join('\n');
+    return html.replace('</head>', () => replacement);
   }
   return html;
 }

--- a/src/output-twine1.ts
+++ b/src/output-twine1.ts
@@ -40,11 +40,12 @@ export function toTwine1HTML(story: ReadonlyStory, format: StoryFormatInfo, star
   const displayStart = startName === 'Start' ? '' : startName;
   template = template.replace('"VERSION"', `Compiled with ${CREATOR_NAME}, ${VERSION}`);
   template = template.replace('"TIME"', `Built on ${new Date().toUTCString()}`);
-  template = template.replace('"START_AT"', `"${jsStringEscape(displayStart)}"`);
+  const startAtValue = `"${jsStringEscape(displayStart)}"`;
+  template = template.replace('"START_AT"', () => startAtValue);
   template = template.replace('"STORY_SIZE"', `"${count}"`);
 
   if (template.includes('"STORY"')) {
-    template = template.replace('"STORY"', data);
+    template = template.replace('"STORY"', () => data);
   } else {
     // Pre-1.4 format: append data + footer
     let footer: string;
@@ -88,7 +89,7 @@ function tryReplaceComponent(template: string, placeholder: string, componentPat
   try {
     let content = readFileSync(componentPath, 'utf-8');
     if (content.charCodeAt(0) === 0xfeff) content = content.slice(1);
-    return template.replace(placeholder, content);
+    return template.replace(placeholder, () => content);
   } catch (e) {
     if (required) {
       throw new Error(

--- a/src/output-twine2.ts
+++ b/src/output-twine2.ts
@@ -27,10 +27,12 @@ export function toTwine2HTML(
   let template = readFormatSource(format);
 
   if (template.includes('{{STORY_NAME}}')) {
-    template = template.replaceAll('{{STORY_NAME}}', htmlEscape(story.name));
+    const name = htmlEscape(story.name);
+    template = template.replaceAll('{{STORY_NAME}}', () => name);
   }
   if (template.includes('{{STORY_DATA}}')) {
-    template = template.replace('{{STORY_DATA}}', getTwine2DataChunk(story, startName, options));
+    const data = getTwine2DataChunk(story, startName, options);
+    template = template.replace('{{STORY_DATA}}', () => data);
   }
 
   return template;

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -93,6 +93,22 @@ describe('modifyHead', () => {
     expect(modifyHead(baseHtml, [])).toBe(baseHtml);
   });
 
+  it('preserves $& and other replacement patterns in module content', () => {
+    const file = join(TMP_DIR, 'regex-lib.js');
+    writeFileSync(file, 'var x = "test".replace(/t/, "$&$&");');
+    const result = modifyHead(baseHtml, [file]);
+    expect(result).toContain('$&$&');
+    expect(result).not.toContain('</head></head>');
+  });
+
+  it("preserves $` and $' replacement patterns in module content", () => {
+    const file = join(TMP_DIR, 'patterns.js');
+    writeFileSync(file, 'var a = "$`"; var b = "$\'";');
+    const result = modifyHead(baseHtml, [file]);
+    expect(result).toContain('$`');
+    expect(result).toContain("$'");
+  });
+
   it('collects diagnostics for missing head file', () => {
     const diagnostics: Diagnostic[] = [];
     const result = modifyHead(baseHtml, [], join(TMP_DIR, 'missing.html'), diagnostics);


### PR DESCRIPTION
## Summary

- Fix `String.replace` `$&` corruption when inlining JS modules — `$&`, `` $` ``, `$'`, and `$<digits>` in module content were silently replaced by special replacement patterns, corrupting bundled JavaScript (#46)
- Fix same corruption pattern in Twine 2 and Twine 1 HTML output renderers
- All `.replace()` calls with user-controlled replacement strings now use function replacements to bypass special pattern interpretation

## Changed files

- `src/modules.ts` — `modifyHead()` replacement
- `src/output-twine1.ts` — `toTwine1HTML()` and `tryReplaceComponent()` replacements
- `src/output-twine2.ts` — `toTwine2HTML()` replacements
- `test/modules.test.ts` — regression tests for `$&`, `` $` ``, and `$'` patterns
- `CHANGELOG.md` — v1.13.1 entry

## Test plan

- [x] Added regression test: JS module with `$&$&` is preserved verbatim in output
- [x] Added regression test: JS module with `` $` `` and `$'` is preserved verbatim
- [x] Verified both tests fail on unaltered code (confirmed `$&` becomes `</head>`)
- [x] All 1216 tests pass after fix
- [x] Typecheck, format, and build all pass

release-npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)